### PR TITLE
test(e2e): increase expect timeout to 15s for Vercel cold-start tolerance

### DIFF
--- a/frontend/playwright.config.cjs
+++ b/frontend/playwright.config.cjs
@@ -74,6 +74,9 @@ module.exports = defineConfig({
   } : {}),
   // Vercel cold starts can take 10-20 s; give each test enough headroom.
   timeout: 60000,
+  // Assertions (expect) get 15 s — matches actionTimeout and handles cold starts
+  // where the login API can take 5-15 s before responding.
+  expect: { timeout: 15000 },
   // Each navigation gets up to 20 s before Playwright times out.
   use: {
     baseURL,


### PR DESCRIPTION
The login-redirect assertion (expect(page).not.toHaveURL(/\/login/)) uses
Playwright's default expect timeout of 5 s. On Vercel cold starts the
Python API can take 5-15 s to respond, causing the admin login test to fail
intermittently when it hits a fresh serverless instance.

Setting expect.timeout to 15000 ms (matching actionTimeout) gives assertions
enough headroom to wait out a cold start before declaring failure.

https://claude.ai/code/session_012zpCLc1crkCjcimfjH4WBy