### PR TITLE
fix: close left panel when text input is focused on mobile

### DIFF
--- a/frontend/src/components/storyEditor/EditorHeader.jsx
+++ b/frontend/src/components/storyEditor/EditorHeader.jsx
@@ -19,6 +19,7 @@ function EditorHeader({
   onSave,
   onPublish,
   onBack,
+  onTitleFocus,
 }) {
   const titleRef = useRef(null)
   const [titleError, setTitleError] = useState(false)
@@ -55,6 +56,7 @@ function EditorHeader({
           type="text"
           value={title}
           onChange={(e) => handleTitleChange(e.target.value)}
+          onFocus={onTitleFocus}
           placeholder="Tiêu đề câu chuyện…"
           className={`input input-ghost input-sm w-full font-semibold text-base focus:outline-none focus:bg-base-100 rounded ${titleError ? 'input-error' : ''}`}
         />

--- a/frontend/src/components/storyEditor/StoryEditorView.jsx
+++ b/frontend/src/components/storyEditor/StoryEditorView.jsx
@@ -45,6 +45,7 @@ function StoryEditorView({
         onPublish={onPublish}
         isPublished={editor.isPublished}
         onBack={onBack}
+        onTitleFocus={() => setPanelOpen(false)}
       />
 
       <FormattingToolbar editorRef={editorRef} activeFormats={activeFormats} panelOpen={panelOpen} onTogglePanel={() => setPanelOpen(p => !p)} />
@@ -61,6 +62,7 @@ function StoryEditorView({
 
         <main
           className="flex-1 overflow-y-auto cursor-text"
+          onFocus={() => setPanelOpen(false)}
           onClick={(e) => {
             // Focus editor when clicking outside the actual ProseMirror content area
             if (!e.target.closest('.ProseMirror')) {


### PR DESCRIPTION
When the user taps the story editor or title input on mobile, the keyboard
appears but the GPT tools panel was staying open and overlapping the content.

Added onFocus handlers to the main editor area and title input that call
setPanelOpen(false). On desktop the panel is always visible via md: CSS
overrides so this has no effect there.

https://claude.ai/code/session_017ZwNp6QdSzvhTLqVJLdiJt