### PR TITLE
perf: paginate world stories endpoint and exclude full content from list view

### DIFF
--- a/api/interfaces/routes/world_routes.py
+++ b/api/interfaces/routes/world_routes.py
@@ -11,12 +11,13 @@ from core.exceptions import (
 )
 from services import CharacterService, PermissionService, NovelService
 from interfaces.auth_middleware import token_required, optional_auth
-from utils.responses import success_response, created_response, deleted_response
+from utils.responses import success_response, created_response, deleted_response, paginated_response
 from utils.validation import validate_request, validate_query_params, extract_pagination
 from schemas.world_schemas import (
     CreateWorldSchema,
     UpdateWorldSchema,
     ListWorldsQuerySchema,
+    ListWorldStoriesQuerySchema,
     CreateEntitySchema,
     UpdateEntitySchema,
     UpdateNovelSchema,
@@ -311,15 +312,42 @@ def create_world_bp(storage, world_generator, diagram_generator, flush_data):
 
     @world_bp.route('/api/worlds/<world_id>/stories', methods=['GET'])
     @optional_auth
+    @validate_query_params(ListWorldStoriesQuerySchema)
     def world_stories(world_id):
-        """Get all stories in a world."""
+        """Get stories in a world (paginated, without full content).
+        ---
+        tags:
+          - Worlds
+        parameters:
+          - in: path
+            name: world_id
+            type: string
+            required: true
+          - in: query
+            name: page
+            type: integer
+            default: 1
+          - in: query
+            name: per_page
+            type: integer
+            default: 20
+        responses:
+          200:
+            description: Paginated story summaries (content_preview instead of full content)
+        """
         world_data = storage.load_world(world_id)
         if not world_data:
             raise ResourceNotFoundError('World', world_id)
 
+        params = request.validated_data
+        page = params.get('page', 1)
+        per_page = params.get('per_page', 20)
         user_id = g.current_user.user_id if hasattr(g, 'current_user') else None
-        stories = storage.list_stories(world_id, user_id=user_id)
-        return success_response(stories)
+
+        items, total = storage.list_stories_summary(
+            world_id, user_id=user_id, page=page, per_page=per_page,
+        )
+        return paginated_response(items, page, per_page, total)
 
     @world_bp.route('/api/worlds/<world_id>/characters', methods=['GET'])
     def world_characters(world_id):

--- a/api/schemas/world_schemas.py
+++ b/api/schemas/world_schemas.py
@@ -90,6 +90,20 @@ class ListWorldsQuerySchema(Schema):
     )
 
 
+class ListWorldStoriesQuerySchema(Schema):
+    """Schema for GET /api/worlds/<id>/stories — paginated story summaries."""
+
+    page = fields.Int(
+        validate=validate.Range(min=1),
+        load_default=1
+    )
+
+    per_page = fields.Int(
+        validate=validate.Range(min=1, max=100),
+        load_default=20
+    )
+
+
 class CreateEntitySchema(Schema):
     """Schema for POST /api/worlds/<id>/entities - Add entity to world."""
 

--- a/api/storage/mongo_storage.py
+++ b/api/storage/mongo_storage.py
@@ -11,8 +11,9 @@ Setup:
        MONGODB_URI=mongodb+srv://user:pass@cluster.xxxxx.mongodb.net/story_creator?retryWrites=true&w=majority
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 import logging
+import re
 import threading
 
 logger = logging.getLogger(__name__)
@@ -264,6 +265,57 @@ class MongoStorage:
             s.get('created_at') or '',
         ))
         return docs
+
+    def list_stories_summary(
+        self,
+        world_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List story summaries with pagination, excluding full content.
+
+        Returns a tuple of (page_items, total_count).  Each item carries a
+        ``content_preview`` (first 200 plain-text characters) instead of the
+        full ``content`` field, drastically reducing payload size.
+        """
+        self._connect()
+        perm_query = self._build_permission_query(user_id)
+        query = {'$and': [{'world_id': world_id}, perm_query]} if world_id else perm_query
+
+        total = self.stories.count_documents(query)
+        if total == 0:
+            return [], 0
+
+        # Fetch metadata only (exclude heavy content field)
+        docs = self._clean_docs(list(self.stories.find(query, {'content': 0})))
+
+        # Sort: order ASC (nulls last), created_at ASC
+        docs.sort(key=lambda s: (
+            (0, s['order']) if s.get('order') is not None else (1, 0),
+            s.get('created_at') or '',
+        ))
+
+        # Slice for current page
+        start = (page - 1) * per_page
+        page_docs = docs[start:start + per_page]
+
+        # Fetch content preview for current page only (avoids loading all content)
+        page_ids = [d['story_id'] for d in page_docs]
+        if page_ids:
+            previews: Dict[str, str] = {}
+            for cd in self.stories.find(
+                {'story_id': {'$in': page_ids}},
+                {'story_id': 1, 'content': 1, '_id': 0},
+            ):
+                raw = cd.get('content') or ''
+                plain = re.sub(r'<[^>]*>', '', raw)[:200]
+                previews[cd['story_id']] = plain
+
+            for d in page_docs:
+                d['content_preview'] = previews.get(d['story_id'], '')
+
+        return page_docs, total
 
     def delete_story(self, story_id: str) -> bool:
         self._connect()

--- a/frontend/src/components/worldDetail/WorldDetailView.jsx
+++ b/frontend/src/components/worldDetail/WorldDetailView.jsx
@@ -57,6 +57,10 @@ function WorldDetailView({
   inviteLoading = false,
   onInviteCollaborator,
   onRemoveCollaborator,
+  // Pagination props
+  hasMoreStories = false,
+  loadingMoreStories = false,
+  onLoadMoreStories,
 }) {
   const { t } = useTranslation()
   const [editingEntityId, setEditingEntityId] = useState(null)
@@ -249,6 +253,9 @@ function WorldDetailView({
             getStoryWorldTime={getStoryWorldTime}
             getTimelineLabel={getTimelineLabel}
             onDeleteStory={canEdit ? onDeleteStory : null}
+            hasMore={hasMoreStories}
+            loadingMore={loadingMoreStories}
+            onLoadMore={onLoadMoreStories}
           />
         </div>
       )}

--- a/frontend/src/components/worldDetail/WorldTimeline.jsx
+++ b/frontend/src/components/worldDetail/WorldTimeline.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import Tag from '../Tag'
 import {
   UserIcon,
@@ -9,7 +10,8 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline'
 
-function WorldTimeline({ stories, characters = [], locations = [], getStoryWorldTime, getTimelineLabel, onDeleteStory }) {
+function WorldTimeline({ stories, characters = [], locations = [], getStoryWorldTime, getTimelineLabel, onDeleteStory, hasMore = false, loadingMore = false, onLoadMore }) {
+  const { t } = useTranslation()
   // Spec BR-1/BR-2 — sort by (order ASC, created_at ASC). Legacy stories
   // with no `order` are pushed to the end.
   const sortedStories = useMemo(() => (
@@ -57,6 +59,7 @@ function WorldTimeline({ stories, characters = [], locations = [], getStoryWorld
   }))
 
   return (
+    <>
     <ul className="timeline timeline-vertical max-md:timeline-compact">
       {yearGroups.map((group, groupIndex) => {
         // Use first story's genre for the line color
@@ -120,9 +123,11 @@ function WorldTimeline({ stories, characters = [], locations = [], getStoryWorld
                         </button>
                       )}
                     </div>
-                    {story.content && (
+                    {(story.content_preview || story.content) && (
                       <p className="text-sm text-base-content/60 mt-1 line-clamp-2">
-                        {story.content.replace(/<[^>]*>/g, '').slice(0, 120)}
+                        {story.content_preview
+                          ? story.content_preview.slice(0, 120)
+                          : story.content.replace(/<[^>]*>/g, '').slice(0, 120)}
                       </p>
                     )}
                     <div className="flex items-center gap-2 mt-1 text-xs text-base-content/40">
@@ -182,6 +187,20 @@ function WorldTimeline({ stories, characters = [], locations = [], getStoryWorld
         )
       })}
     </ul>
+    {hasMore && (
+      <div className="flex justify-center mt-6">
+        <button
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          className="btn btn-outline btn-primary btn-sm gap-2"
+        >
+          {loadingMore
+            ? <><span className="loading loading-spinner loading-xs"></span> {t('pages.worldDetail.loadingMoreStories')}</>
+            : t('pages.worldDetail.loadMoreStories')}
+        </button>
+      </div>
+    )}
+    </>
   )
 }
 

--- a/frontend/src/containers/WorldDetailContainer.jsx
+++ b/frontend/src/containers/WorldDetailContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
@@ -9,6 +9,8 @@ import WorldDetailView from '../components/worldDetail/WorldDetailView'
 import { useAuth } from '../contexts/AuthContext'
 import { useGptTasks } from '../contexts/GptTaskContext'
 
+const STORIES_PER_PAGE = 20
+
 function WorldDetailContainer({ showToast }) {
   const { t } = useTranslation()
   const { worldId } = useParams()
@@ -16,6 +18,9 @@ function WorldDetailContainer({ showToast }) {
   const { registerTask } = useGptTasks()
   const [world, setWorld] = useState(null)
   const [stories, setStories] = useState([])
+  const [storiesTotalPages, setStoriesTotalPages] = useState(0)
+  const [storiesPage, setStoriesPage] = useState(1)
+  const [loadingMoreStories, setLoadingMoreStories] = useState(false)
   const [characters, setCharacters] = useState([])
   const [locations, setLocations] = useState([])
   const [activeTab, setActiveTab] = useState('stories')
@@ -45,7 +50,7 @@ function WorldDetailContainer({ showToast }) {
       setLoading(true)
       const [worldRes, storiesRes, charsRes, locsRes, collabRes] = await Promise.all([
         worldsAPI.getById(worldId),
-        worldsAPI.getStories(worldId),
+        worldsAPI.getStories(worldId, { page: 1, perPage: STORIES_PER_PAGE }),
         worldsAPI.getCharacters(worldId),
         worldsAPI.getLocations(worldId),
         collaboratorsAPI.list(worldId).catch(() => ({ data: [] })),
@@ -53,6 +58,8 @@ function WorldDetailContainer({ showToast }) {
 
       setWorld(worldRes.data)
       setStories(storiesRes.data)
+      setStoriesPage(1)
+      setStoriesTotalPages(storiesRes.pagination?.total_pages ?? 1)
       setCharacters(charsRes.data)
       setLocations(locsRes.data)
       setCollaborators(collabRes.data || [])
@@ -63,6 +70,22 @@ function WorldDetailContainer({ showToast }) {
       setLoading(false)
     }
   }
+
+  const handleLoadMoreStories = useCallback(async () => {
+    const nextPage = storiesPage + 1
+    if (nextPage > storiesTotalPages || loadingMoreStories) return
+    try {
+      setLoadingMoreStories(true)
+      const res = await worldsAPI.getStories(worldId, { page: nextPage, perPage: STORIES_PER_PAGE })
+      setStories(prev => [...prev, ...res.data])
+      setStoriesPage(nextPage)
+      setStoriesTotalPages(res.pagination?.total_pages ?? storiesTotalPages)
+    } catch (error) {
+      showToast(t('pages.worldDetail.loadError'), 'error')
+    } finally {
+      setLoadingMoreStories(false)
+    }
+  }, [worldId, storiesPage, storiesTotalPages, loadingMoreStories, showToast, t])
 
   const computeWorldTimeFromIndex = (timeIndex) => {
     if (!world) return null
@@ -342,6 +365,10 @@ function WorldDetailContainer({ showToast }) {
       inviteLoading={inviteLoading}
       onInviteCollaborator={handleInviteCollaborator}
       onRemoveCollaborator={handleRemoveCollaborator}
+      // Pagination props
+      hasMoreStories={storiesPage < storiesTotalPages}
+      loadingMoreStories={loadingMoreStories}
+      onLoadMoreStories={handleLoadMoreStories}
     />
     </>
   )

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -304,7 +304,9 @@
       "invitePending": "Already a co-author or invitation pending",
       "inviteError": "Failed to send invitation",
       "removeCollabSuccess": "Co-author removed",
-      "removeCollabError": "Failed to remove co-author"
+      "removeCollabError": "Failed to remove co-author",
+      "loadMoreStories": "Load more stories",
+      "loadingMoreStories": "Loading..."
     },
     "storyDetail": {
       "loadError": "Failed to load story details",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -304,7 +304,9 @@
       "invitePending": "Đã là đồng tác giả hoặc lời mời đang chờ",
       "inviteError": "Không thể gửi lời mời",
       "removeCollabSuccess": "Đã xóa đồng tác giả",
-      "removeCollabError": "Không thể xóa đồng tác giả"
+      "removeCollabError": "Không thể xóa đồng tác giả",
+      "loadMoreStories": "Tải thêm câu chuyện",
+      "loadingMoreStories": "Đang tải..."
     },
     "storyDetail": {
       "loadError": "Không thể tải chi tiết câu chuyện",

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -23,6 +23,7 @@ api.interceptors.request.use(
 
 // Unwrap standard API response envelope: { success: true, data: X } → response.data = X
 // GPT endpoints use jsonify() directly (no envelope) so they are unaffected.
+// Pagination metadata (if present) is preserved on response.pagination.
 api.interceptors.response.use(
   (response) => {
     if (
@@ -31,6 +32,9 @@ api.interceptors.response.use(
       'success' in response.data &&
       'data' in response.data
     ) {
+      if (response.data.pagination) {
+        response.pagination = response.data.pagination
+      }
       response.data = response.data.data
     }
     return response
@@ -46,7 +50,8 @@ export const worldsAPI = {
   update: (id, data) => api.put(`/worlds/${id}`, data),
   delete: (id) => api.delete(`/worlds/${id}`),
   getCharacters: (id) => api.get(`/worlds/${id}/characters`),
-  getStories: (id) => api.get(`/worlds/${id}/stories`),
+  getStories: (id, { page = 1, perPage = 20 } = {}) =>
+    api.get(`/worlds/${id}/stories`, { params: { page, per_page: perPage } }),
   getLocations: (id) => api.get(`/worlds/${id}/locations`),
   autoLinkStories: (id) => api.post(`/worlds/${id}/auto-link-stories`),
   deleteEntity: (worldId, entityId) => api.delete(`/worlds/${worldId}/entities/${entityId}`),


### PR DESCRIPTION
When a world has 500+ stories (each ~5000 words), the previous implementation
loaded all stories with full content in a single request (~12.5MB). Now the
endpoint returns paginated summaries with content_preview (200 chars) instead
of full content, reducing initial payload from ~12.5MB to ~26KB (20 stories).

Backend: add list_stories_summary() with MongoDB projection + pagination.
Frontend: add "load more" button with incremental story loading.

https://claude.ai/code/session_01XNAMnQ3RmEo67gKtvYa27P