### PR TITLE
feat: story editor improvements — draft save, signature modal, unsaved warning, novel markdown, author token

### DIFF
--- a/api/core/models/story.py
+++ b/api/core/models/story.py
@@ -55,6 +55,7 @@ class Story:
         self.owner_id = owner_id
         self.shared_with = shared_with or []
         self.format = format  # 'plain' | 'markdown'
+        self.author_signature = None  # {token: str, display: str, owner_id: str} — token is immutable after creation
         self.locations: List[str] = []  # Location IDs where story takes place
         self.entities: List[str] = []  # Entity IDs participating in story
         self.time_cones: List[str] = []  # Time cone IDs for temporal context
@@ -77,6 +78,7 @@ class Story:
             "owner_id": self.owner_id,
             "shared_with": self.shared_with,
             "format": self.format,
+            "author_signature": self.author_signature,
             "locations": self.locations,
             "entities": self.entities,
             "time_cones": self.time_cones,
@@ -105,6 +107,7 @@ class Story:
             shared_with=data.get("shared_with", []),
             format=data.get("format", "plain")
         )
+        story.author_signature = data.get("author_signature")
         story.locations = data.get("locations", [])
         story.entities = data.get("entities", [])
         story.time_cones = data.get("time_cones", [])

--- a/api/core/models/user.py
+++ b/api/core/models/user.py
@@ -89,6 +89,8 @@ class User:
         'gpt_requests_per_day',
         'gpt_requests_today',
         'gpt_last_reset',
+        'signature',
+        'signatures',
     )
 
     def to_safe_dict(self) -> Dict[str, Any]:

--- a/api/interfaces/routes/auth_routes.py
+++ b/api/interfaces/routes/auth_routes.py
@@ -269,6 +269,8 @@ def create_auth_bp(storage, auth_service, limiter=None):
             user_data['email'] = data['email']
         if 'signature' in data:
             user_data.setdefault('metadata', {})['signature'] = data['signature']
+        if 'signatures' in data:
+            user_data.setdefault('metadata', {})['signatures'] = data['signatures']
 
         storage.save_user(user_data)
         user_data.pop('password_hash', None)

--- a/api/interfaces/routes/story_routes.py
+++ b/api/interfaces/routes/story_routes.py
@@ -1,5 +1,6 @@
 """Story routes for the API backend."""
 
+import uuid as _uuid
 from datetime import datetime
 from flask import Blueprint, request, g
 from core.models.world import World
@@ -161,6 +162,15 @@ def create_story_bp(storage, story_generator, flush_data):
         story.owner_id = g.current_user.user_id
         story.visibility = visibility
         story.format = data['format']
+
+        # Auto-create an immutable author token on first save
+        _user_data = storage.load_user(g.current_user.user_id) or {}
+        _user_sig = _user_data.get('metadata', {}).get('signature') or g.current_user.username
+        story.author_signature = {
+            'token': str(_uuid.uuid4()),
+            'display': _user_sig,
+            'owner_id': g.current_user.user_id,
+        }
         if data['content']:
             story.content = data['content']
 
@@ -376,6 +386,13 @@ def create_story_bp(storage, story_generator, flush_data):
             story_data['chapter_number'] = data['chapter_number']
         if data.get('order') is not None:
             story_data['order'] = data['order']
+        if 'author_signature' in data:
+            existing = story_data.get('author_signature') or {}
+            story_data['author_signature'] = {
+                'token': existing.get('token') or str(_uuid.uuid4()),
+                'display': data['author_signature'].get('display', existing.get('display', '')),
+                'owner_id': existing.get('owner_id') or story_data.get('owner_id'),
+            }
 
         story_data['updated_at'] = datetime.now().isoformat()
         storage.save_story(story_data)

--- a/api/schemas/auth_schemas.py
+++ b/api/schemas/auth_schemas.py
@@ -122,6 +122,11 @@ class UpdateProfileSchema(Schema):
         allow_none=True
     )
 
+    signatures = fields.List(
+        fields.Str(validate=validate.Length(min=1, max=200)),
+        validate=validate.Length(max=20)
+    )
+
     @validates('username')
     def validate_username(self, value, **kwargs):
         """Validate username contains only allowed characters."""

--- a/api/schemas/story_schemas.py
+++ b/api/schemas/story_schemas.py
@@ -108,6 +108,8 @@ class UpdateStorySchema(Schema):
         validate=validate.Range(min=1)
     )
 
+    author_signature = fields.Dict(keys=fields.Str(), values=fields.Raw())
+
     @validates_schema
     def validate_not_empty(self, data, **kwargs):
         """Ensure at least one field is being updated."""

--- a/frontend/e2e/storyEditor.spec.cjs
+++ b/frontend/e2e/storyEditor.spec.cjs
@@ -88,7 +88,7 @@ test.describe('Story Editor', () => {
     await editor.type('Hi')
 
     // Blur using the title input (reliably focusable)
-    await page.locator('input').first().click()
+    await page.locator('input[placeholder*="tiêu đề"], input[placeholder*="Tiêu đề"], input[placeholder*="title"], input[placeholder*="Title"]').first().click()
     await expect(editor).not.toBeFocused({ timeout: 2000 })
 
     // Click in the editor area well below the text, but within the visible viewport.

--- a/frontend/src/components/ThemeSelector.jsx
+++ b/frontend/src/components/ThemeSelector.jsx
@@ -31,7 +31,7 @@ function ThemeSelector() {
   }
 
   return (
-    <div className="flex flex-col gap-2 p-2">
+    <div className="flex flex-col gap-2 p-4">
       {/* Theme mode buttons */}
       <div className="flex gap-1">
         {MODES.map(({ id, labelKey }) => (
@@ -46,7 +46,7 @@ function ThemeSelector() {
       </div>
 
       {/* Color swatches — style={{ backgroundColor }} is intentional (palette preview) */}
-      <div className="flex gap-1 justify-center">
+      <div className="flex gap-1 justify-start">
         {SWATCHES.map(({ key, labelKey }) => (
           <div
             key={key}
@@ -58,21 +58,19 @@ function ThemeSelector() {
       </div>
 
       {/* Custom primary color picker */}
-      {mode === THEME_MODES.CUSTOM && (
-        <div className="flex items-center gap-2">
-          <span className="text-xs opacity-70">{t('theme.primary')}</span>
-          <input
-            type="color"
-            value={primaryColor}
-            onChange={(e) => setPrimaryColor(e.target.value)}
-            className="w-8 h-8 rounded cursor-pointer border-0 bg-transparent"
-          />
-        </div>
-      )}
+      <div className="flex items-center gap-2">
+        <span className="text-xs opacity-70">{t('theme.primary')}</span>
+        <input
+          type="color"
+          value={primaryColor}
+          onChange={(e) => setPrimaryColor(e.target.value)}
+          className="w-8 h-8 rounded cursor-pointer border-0 bg-transparent"
+        />
+      </div>
 
       {/* Language toggle */}
       <div className="border-t border-base-300 pt-2 mt-1">
-        <p className="text-xs opacity-60 mb-1">{t('theme.language')}</p>
+        <p className="text-xs opacity-60 mb-2">{t('theme.language')}</p>
         <div className="flex gap-1">
           {LANGUAGES.map(({ code, labelKey }) => (
             <button

--- a/frontend/src/components/novel/NovelContentStream.jsx
+++ b/frontend/src/components/novel/NovelContentStream.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { marked } from 'marked'
 
 /**
  * Stream of chapter content blocks.
@@ -34,9 +35,10 @@ function NovelContentStream({ blocks }) {
                 </Link>
               </header>
             )}
-            <div className="prose prose-lg max-w-none whitespace-pre-wrap leading-relaxed">
-              {block.content}
-            </div>
+            <div
+              className="prose prose-lg max-w-none leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: marked.parse(block.content || '') }}
+            />
             {!block.is_complete && (
               <p className="opacity-60 italic mt-4">
                 {t('pages.novel.continued')}

--- a/frontend/src/components/storyEditor/EditorHeader.jsx
+++ b/frontend/src/components/storyEditor/EditorHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 
@@ -16,7 +16,6 @@ function EditorHeader({
 }) {
   const { t } = useTranslation()
   const titleRef = useRef(null)
-  const [titleError, setTitleError] = useState(false)
 
   const STATUS_TEXT = {
     new:    { cls: 'text-base-content/40',          label: t('pages.storyEditor.statusNew')    },
@@ -27,23 +26,8 @@ function EditorHeader({
   }
   const badge = STATUS_TEXT[saveStatus] || STATUS_TEXT.idle
 
-  const handleSave = () => {
-    if (!title.trim()) {
-      setTitleError(true)
-      titleRef.current?.focus()
-      return
-    }
-    setTitleError(false)
-    onSave()
-  }
-
-  const handleTitleChange = (value) => {
-    if (value.trim()) setTitleError(false)
-    onTitleChange(value)
-  }
-
   return (
-    <header className="flex items-center flex-wrap gap-1 px-3 py-1.5 bg-base-100 border-b border-base-300 shrink-0">
+    <header className="sticky top-0 z-10 flex items-center flex-wrap gap-1 px-3 py-1.5 bg-base-100 border-b border-base-300 shrink-0">
       <button
         onClick={onBack}
         className="btn btn-xs btn-ghost h-7 min-h-0 px-2 shrink-0"
@@ -52,21 +36,16 @@ function EditorHeader({
         <ArrowLeftIcon className="w-4 h-4" />
       </button>
 
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 min-w-0">
         <input
           ref={titleRef}
           type="text"
           value={title}
-          onChange={(e) => handleTitleChange(e.target.value)}
+          onChange={(e) => onTitleChange(e.target.value)}
           onFocus={onTitleFocus}
           placeholder={t('pages.storyEditor.titlePlaceholder')}
-          className={`bg-transparent border-0 outline-none h-7 w-full font-semibold text-sm px-2 rounded placeholder:text-base-content/30 hover:bg-base-200/60 focus:bg-base-200 transition-colors ${titleError ? 'ring-1 ring-error' : ''}`}
+          className="bg-transparent border-0 outline-none h-7 w-full font-semibold text-sm px-2 rounded placeholder:text-base-content/30 hover:bg-base-200/60 focus:bg-base-200 transition-colors"
         />
-        {titleError && (
-          <span className="text-error text-xs px-1">
-            {t('pages.storyEditor.titleRequired')}
-          </span>
-        )}
       </div>
 
       <div className="flex items-center gap-1 shrink-0">
@@ -78,7 +57,7 @@ function EditorHeader({
           </span>
         )}
 
-        {saveStatus === 'saved' && !isPublished && title.trim() && wordCount > 0 && (
+        {saveStatus === 'saved' && !isPublished && wordCount > 0 && (
           <button
             onClick={onPublish}
             className="btn btn-xs btn-outline btn-success h-7 min-h-0 px-2 shrink-0"
@@ -87,7 +66,7 @@ function EditorHeader({
           </button>
         )}
         <button
-          onClick={handleSave}
+          onClick={onSave}
           className="btn btn-xs btn-primary h-7 min-h-0 px-2 shrink-0"
         >
           {t('pages.storyEditor.save')}

--- a/frontend/src/components/storyEditor/LeftPanel.jsx
+++ b/frontend/src/components/storyEditor/LeftPanel.jsx
@@ -1,12 +1,28 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import GptToolsPanel from './GptToolsPanel'
 import DocumentOutline from './DocumentOutline'
+import SignatureModal from './SignatureModal'
 import { PencilSquareIcon } from '@heroicons/react/24/outline'
 
-function LeftPanel({ gpt, headings, userSignature, onInsertSignature, panelOpen, onClosePanel }) {
+function LeftPanel({
+  gpt,
+  headings,
+  signatures,
+  showSignatureModal,
+  onOpenSignatureModal,
+  onCloseSignatureModal,
+  onSignaturesChange,
+  onInsertSignature,
+  panelOpen,
+  onClosePanel,
+  showToast,
+}) {
+  const { t } = useTranslation()
+
   return (
     <>
-      {/* Mobile backdrop — tap to close */}
+      {/* Mobile backdrop */}
       {panelOpen && (
         <div
           className="md:hidden fixed inset-0 bg-black/50 z-10"
@@ -16,12 +32,10 @@ function LeftPanel({ gpt, headings, userSignature, onInsertSignature, panelOpen,
 
       <aside className={[
         'flex flex-col gap-5 p-4 bg-base-100 overflow-y-auto',
-        // Mobile: full-width bottom sheet
         'fixed bottom-0 left-0 right-0 z-20 max-h-[75vh]',
         'rounded-t-2xl border-t border-base-300 shadow-2xl',
         'transition-transform duration-300 ease-out',
         panelOpen ? 'translate-y-0' : 'translate-y-full',
-        // Desktop: always-visible left sidebar
         'md:relative md:inset-auto md:max-h-none md:h-auto',
         'md:rounded-none md:border-t-0 md:border-r md:shadow-none',
         'md:translate-y-0 md:w-56 md:shrink-0',
@@ -38,16 +52,16 @@ function LeftPanel({ gpt, headings, userSignature, onInsertSignature, panelOpen,
 
         <div className="space-y-2">
           <div className="text-xs font-semibold text-base-content/60 uppercase tracking-wider">
-            Signature
+            {t('pages.signatureModal.title')}
           </div>
           <button
-            onClick={onInsertSignature}
-            disabled={!userSignature}
+            onClick={onOpenSignatureModal}
             className="btn btn-sm btn-outline w-full justify-start gap-2"
-            title={userSignature ? `Insert: — ${userSignature}` : 'No signature set'}
           >
             <PencilSquareIcon className="w-4 h-4" />
-            {userSignature ? 'Insert sig' : 'No signature'}
+            {signatures.length > 0
+              ? t('pages.signatureModal.manage')
+              : t('pages.signatureModal.noSignature')}
           </button>
         </div>
 
@@ -60,6 +74,16 @@ function LeftPanel({ gpt, headings, userSignature, onInsertSignature, panelOpen,
           <DocumentOutline headings={headings} />
         </div>
       </aside>
+
+      {showSignatureModal && (
+        <SignatureModal
+          signatures={signatures}
+          onClose={onCloseSignatureModal}
+          onInsert={onInsertSignature}
+          onSignaturesChange={onSignaturesChange}
+          showToast={showToast}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/components/storyEditor/SignatureModal.jsx
+++ b/frontend/src/components/storyEditor/SignatureModal.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { XMarkIcon, PlusIcon, TrashIcon, PencilSquareIcon } from '@heroicons/react/24/outline'
+import { authAPI } from '../../services/api'
+
+function SignatureModal({ signatures = [], onClose, onInsert, onSignaturesChange, showToast }) {
+  const { t } = useTranslation()
+  const [newSig, setNewSig] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const addSignature = async () => {
+    const text = newSig.trim()
+    if (!text) return
+    const updated = [...signatures, text]
+    setSaving(true)
+    try {
+      await authAPI.updateProfile({ signatures: updated })
+      onSignaturesChange(updated)
+      setNewSig('')
+    } catch {
+      showToast(t('pages.signatureModal.saveError'), 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const deleteSignature = async (idx) => {
+    const updated = signatures.filter((_, i) => i !== idx)
+    try {
+      await authAPI.updateProfile({ signatures: updated })
+      onSignaturesChange(updated)
+    } catch {
+      showToast(t('pages.signatureModal.saveError'), 'error')
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-sm">
+        <button
+          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          onClick={onClose}
+          aria-label={t('common.close')}
+        >
+          <XMarkIcon className="w-4 h-4" />
+        </button>
+
+        <h3 className="font-bold text-lg mb-4">{t('pages.signatureModal.title')}</h3>
+
+        {signatures.length === 0 ? (
+          <p className="text-sm opacity-60 text-center py-3">{t('pages.signatureModal.empty')}</p>
+        ) : (
+          <ul className="space-y-1 mb-4">
+            {signatures.map((sig, idx) => (
+              <li key={idx} className="flex items-center gap-2 py-1 px-2 rounded hover:bg-base-200">
+                <PencilSquareIcon className="w-4 h-4 opacity-40 shrink-0" />
+                <span className="flex-1 text-sm truncate">— {sig}</span>
+                <button
+                  onClick={() => { onInsert(sig); onClose() }}
+                  className="btn btn-xs btn-primary shrink-0"
+                >
+                  {t('pages.signatureModal.insert')}
+                </button>
+                <button
+                  onClick={() => deleteSignature(idx)}
+                  className="btn btn-xs btn-ghost text-error shrink-0"
+                  aria-label={t('actions.delete')}
+                >
+                  <TrashIcon className="w-3.5 h-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex gap-2 border-t border-base-300 pt-3">
+          <input
+            value={newSig}
+            onChange={e => setNewSig(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && addSignature()}
+            placeholder={t('pages.signatureModal.placeholder')}
+            maxLength={200}
+            className="input input-sm input-bordered flex-1"
+          />
+          <button
+            onClick={addSignature}
+            disabled={!newSig.trim() || saving}
+            className="btn btn-sm btn-primary"
+            aria-label={t('pages.signatureModal.add')}
+          >
+            {saving
+              ? <span className="loading loading-spinner loading-xs" />
+              : <PlusIcon className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+      <div className="modal-backdrop" onClick={onClose} />
+    </dialog>
+  )
+}
+
+export default SignatureModal

--- a/frontend/src/components/storyEditor/StoryEditorView.jsx
+++ b/frontend/src/components/storyEditor/StoryEditorView.jsx
@@ -14,15 +14,20 @@ function StoryEditorView({
   editorRef,
   gpt,
   activeFormats,
-  userSignature,
+  signatures,
+  showSignatureModal,
+  onOpenSignatureModal,
+  onCloseSignatureModal,
+  onSignaturesChange,
+  onInsertSignature,
   onTitleChange,
   onContentUpdate,
   onSelectionChange,
   onSave,
   onPublish,
   onBack,
-  onInsertSignature,
   initialFormat,
+  showToast,
 }) {
   const [panelOpen, setPanelOpen] = useState(false)
 
@@ -66,19 +71,22 @@ function StoryEditorView({
         <LeftPanel
           gpt={gpt}
           headings={headings}
-          userSignature={userSignature}
+          signatures={signatures}
+          showSignatureModal={showSignatureModal}
+          onOpenSignatureModal={onOpenSignatureModal}
+          onCloseSignatureModal={onCloseSignatureModal}
+          onSignaturesChange={onSignaturesChange}
           onInsertSignature={onInsertSignature}
           panelOpen={panelOpen}
           onClosePanel={() => setPanelOpen(false)}
+          showToast={showToast}
         />
 
         <main
           className="flex-1 overflow-y-auto cursor-text"
           onFocus={() => setPanelOpen(false)}
           onClick={(e) => {
-            // Focus editor when clicking outside the actual ProseMirror content area
             if (!e.target.closest('.ProseMirror')) {
-              // Direct DOM focus avoids TipTap's internal setTimeout delay
               const pm = e.currentTarget.querySelector('.ProseMirror')
               pm?.focus()
               editorRef.current?.commands.focus('end')

--- a/frontend/src/components/storyEditor/TitleSuggestionModal.jsx
+++ b/frontend/src/components/storyEditor/TitleSuggestionModal.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+function TitleSuggestionModal({ suggestion, onConfirm, onSkip, onCancel }) {
+  const { t } = useTranslation()
+  const [title, setTitle] = useState(suggestion || '')
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-sm">
+        <h3 className="font-bold text-lg">{t('pages.storyEditor.titleSuggestTitle')}</h3>
+        <p className="text-sm opacity-60 mb-3 mt-1">{t('pages.storyEditor.titleSuggestMessage')}</p>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && title.trim()) onConfirm(title.trim()) }}
+          placeholder={t('pages.storyEditor.titleSuggestPlaceholder')}
+          className="input input-bordered w-full"
+          autoFocus
+          maxLength={200}
+        />
+        <div className="modal-action gap-2 flex-wrap">
+          <button onClick={onCancel} className="btn btn-ghost btn-sm">
+            {t('common.cancel')}
+          </button>
+          <button onClick={onSkip} className="btn btn-ghost btn-sm">
+            {t('pages.storyEditor.titleSuggestSkip')}
+          </button>
+          <button
+            onClick={() => onConfirm(title.trim())}
+            disabled={!title.trim()}
+            className="btn btn-primary btn-sm"
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+      <div className="modal-backdrop" onClick={onCancel} />
+    </dialog>
+  )
+}
+
+export default TitleSuggestionModal

--- a/frontend/src/components/storyEditor/UnsavedChangesModal.jsx
+++ b/frontend/src/components/storyEditor/UnsavedChangesModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+function UnsavedChangesModal({ onSave, onDiscard, onCancel }) {
+  const { t } = useTranslation()
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-sm">
+        <h3 className="font-bold text-lg">{t('pages.storyEditor.unsavedTitle')}</h3>
+        <p className="py-3 text-sm opacity-70">{t('pages.storyEditor.unsavedMessage')}</p>
+        <div className="modal-action gap-2">
+          <button onClick={onCancel} className="btn btn-ghost btn-sm">
+            {t('common.cancel')}
+          </button>
+          <button onClick={onDiscard} className="btn btn-error btn-outline btn-sm">
+            {t('pages.storyEditor.discard')}
+          </button>
+          <button onClick={onSave} className="btn btn-primary btn-sm">
+            {t('pages.storyEditor.saveDraft')}
+          </button>
+        </div>
+      </div>
+      <div className="modal-backdrop" onClick={onCancel} />
+    </dialog>
+  )
+}
+
+export default UnsavedChangesModal

--- a/frontend/src/containers/StoryEditorContainer.jsx
+++ b/frontend/src/containers/StoryEditorContainer.jsx
@@ -8,7 +8,6 @@ import { useAuth } from '../contexts/AuthContext'
 import StoryEditorView from '../components/storyEditor/StoryEditorView'
 import UnsavedChangesModal from '../components/storyEditor/UnsavedChangesModal'
 import TitleSuggestionModal from '../components/storyEditor/TitleSuggestionModal'
-import SignatureModal from '../components/storyEditor/SignatureModal'
 import TurndownService from 'turndown'
 import { marked } from 'marked'
 
@@ -90,7 +89,6 @@ function StoryEditorContainer({ showToast }) {
 
   // Ctrl+S / Cmd+S keyboard shortcut — use ref so the handler is always current
   const handleSaveRef = useRef(null)
-  useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
   useEffect(() => {
     const onKeyDown = (e) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
@@ -259,6 +257,7 @@ function StoryEditorContainer({ showToast }) {
     }
     doSave()
   }, [doSave])
+  useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
 
   const handleTitleModalConfirm = useCallback((chosenTitle) => {
     setShowTitleModal(false)

--- a/frontend/src/containers/StoryEditorContainer.jsx
+++ b/frontend/src/containers/StoryEditorContainer.jsx
@@ -6,11 +6,19 @@ import { usePageTitle } from '../hooks/usePageTitle'
 import { storiesAPI, gptAPI, authAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import StoryEditorView from '../components/storyEditor/StoryEditorView'
+import UnsavedChangesModal from '../components/storyEditor/UnsavedChangesModal'
+import TitleSuggestionModal from '../components/storyEditor/TitleSuggestionModal'
+import SignatureModal from '../components/storyEditor/SignatureModal'
 import TurndownService from 'turndown'
 import { marked } from 'marked'
 
 const turndownSvc = new TurndownService({ headingStyle: 'atx', bulletListMarker: '-' })
 const toMarkdown = (html) => turndownSvc.turndown(html || '')
+
+const extractTitleSuggestion = (html) => {
+  const text = (html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+  return text.substring(0, 80).trim()
+}
 
 function StoryEditorContainer({ showToast }) {
   const { t } = useTranslation()
@@ -31,7 +39,12 @@ function StoryEditorContainer({ showToast }) {
   const [initialFormat, setInitialFormat] = useState('html')
   const [gpt, setGpt] = useState({ isLoading: false, suggestions: [], selectionLength: 0 })
   const [activeFormats, setActiveFormats] = useState({})
-  const [userSignature, setUserSignature] = useState('')
+  const [signatures, setSignatures] = useState([])
+  const [showUnsavedModal, setShowUnsavedModal] = useState(false)
+  const [pendingNavigate, setPendingNavigate] = useState(null)
+  const [showTitleModal, setShowTitleModal] = useState(false)
+  const [titleSuggestion, setTitleSuggestion] = useState('')
+  const [showSignatureModal, setShowSignatureModal] = useState(false)
   const editTitle = usePageTitle('storyEdit', editor.title || null)
 
   // Refs — mirror mutable values so doSave is always reading current data (no stale closures)
@@ -44,9 +57,6 @@ function StoryEditorContainer({ showToast }) {
   const gptSelectionRef = useRef(null)
 
   useEffect(() => {
-    // Wait for token verification before deciding user is unauthenticated.
-    // Without this guard, a direct page load (full URL navigation) triggers a
-    // redirect to /login before verifyToken resolves — visible on Vercel cold starts.
     if (!authLoading && user === null) {
       navigate('/login')
     }
@@ -55,14 +65,41 @@ function StoryEditorContainer({ showToast }) {
   useEffect(() => {
     if (!user) return
     const storyLoad = storyId ? loadStory() : checkForDraft()
-    Promise.all([storyLoad, loadUserSignature()])
+    Promise.all([storyLoad, loadUserSignatures()])
   }, [user, storyId])
 
+  // Flush on unmount
   useEffect(() => {
     return () => {
       clearTimeout(saveTimerRef.current)
       doSave()
     }
+  }, [])
+
+  // Warn on browser close/refresh when dirty
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (isDirty()) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [])
+
+  // Ctrl+S / Cmd+S keyboard shortcut — use ref so the handler is always current
+  const handleSaveRef = useRef(null)
+  useEffect(() => { handleSaveRef.current = handleSave }, [handleSave])
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault()
+        handleSaveRef.current?.()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
   const loadStory = async () => {
@@ -71,9 +108,7 @@ function StoryEditorContainer({ showToast }) {
       const data = res.data
       const title = data.title || ''
       const rawContent = data.content || ''
-      // Always load into the editor as HTML; convert markdown→HTML when needed
       const editorContent = data.format === 'markdown' ? marked.parse(rawContent) : rawContent
-      // lastSavedRef tracks markdown so dirty-check works after round-trip
       const markdownBaseline = data.format === 'markdown' ? rawContent : toMarkdown(rawContent)
       storyIdRef.current = storyId
       setInitialFormat('html')
@@ -95,14 +130,29 @@ function StoryEditorContainer({ showToast }) {
     setEditor(prev => ({ ...prev, isLoading: false }))
   }
 
-  const loadUserSignature = async () => {
+  const loadUserSignatures = async () => {
     try {
       const res = await authAPI.getCurrentUser()
-      setUserSignature(res.data?.signature || '')
+      const meta = res.data?.metadata || {}
+      // Support both new `signatures` array and legacy single `signature`
+      const sigList = Array.isArray(meta.signatures) && meta.signatures.length > 0
+        ? meta.signatures
+        : (meta.signature ? [meta.signature] : [])
+      setSignatures(sigList)
     } catch {
       // not critical
     }
   }
+
+  const isDirty = useCallback(() => {
+    const { title, content } = editorDataRef.current
+    const markdownContent = toMarkdown(content)
+    const last = lastSavedRef.current
+    if (!storyIdRef.current) {
+      return title.trim() !== '' || markdownContent.trim() !== ''
+    }
+    return title !== last.title || markdownContent !== last.content
+  }, [])
 
   const wordCount = useMemo(() => {
     const raw = editorRef.current
@@ -122,30 +172,31 @@ function StoryEditorContainer({ showToast }) {
       .map(n => ({ level: n.attrs?.level ?? 1, text: n.content?.[0]?.text ?? '' }))
   }, [editor.content])
 
-  // doSave reads from refs — stable callback, no stale closure issues
   const doSave = useCallback(async () => {
-    const { title, content } = editorDataRef.current  // HTML from editor
+    const { title, content } = editorDataRef.current
     const markdownContent = toMarkdown(content)
-    const last = lastSavedRef.current  // markdown baseline
+    const last = lastSavedRef.current
     if (title === last.title && markdownContent === last.content) return
-    if (!storyIdRef.current && !title.trim()) return
+
+    // Allow saving without title — fallback to "(no title)"
+    const effectiveTitle = title.trim() || t('pages.storyEditor.titleNoTitle')
 
     setEditor(prev => ({ ...prev, saveStatus: 'saving' }))
     try {
       if (!storyIdRef.current) {
         const res = await storiesAPI.create({
           world_id: worldIdRef.current,
-          title: title.trim(),
+          title: effectiveTitle,
           content: markdownContent,
           visibility: 'draft',
           format: 'markdown',
         })
         storyIdRef.current = res.data.story_id
-        lastSavedRef.current = { title, content: markdownContent }
+        lastSavedRef.current = { title: effectiveTitle, content: markdownContent }
         setEditor(prev => ({ ...prev, saveStatus: 'saved' }))
       } else {
-        await storiesAPI.patch(storyIdRef.current, { title, content: markdownContent, format: 'markdown' })
-        lastSavedRef.current = { title, content: markdownContent }
+        await storiesAPI.patch(storyIdRef.current, { title: effectiveTitle, content: markdownContent, format: 'markdown' })
+        lastSavedRef.current = { title: effectiveTitle, content: markdownContent }
         setEditor(prev => ({ ...prev, saveStatus: 'saved' }))
       }
     } catch (err) {
@@ -197,10 +248,62 @@ function StoryEditorContainer({ showToast }) {
     setActiveFormats(getActiveFormats(editorInstance))
   }, [getActiveFormats])
 
+  // Manual save — shows title modal if title is empty but content exists
   const handleSave = useCallback(() => {
     clearTimeout(saveTimerRef.current)
+    const { title, content } = editorDataRef.current
+    if (!title.trim() && (content || '').replace(/<[^>]+>/g, '').trim()) {
+      setTitleSuggestion(extractTitleSuggestion(content))
+      setShowTitleModal(true)
+      return
+    }
     doSave()
   }, [doSave])
+
+  const handleTitleModalConfirm = useCallback((chosenTitle) => {
+    setShowTitleModal(false)
+    editorDataRef.current = { ...editorDataRef.current, title: chosenTitle }
+    setEditor(prev => ({ ...prev, title: chosenTitle }))
+    doSave()
+  }, [doSave])
+
+  const handleTitleModalSkip = useCallback(() => {
+    setShowTitleModal(false)
+    doSave()
+  }, [doSave])
+
+  const doNavigateBack = useCallback(() => {
+    navigate(storyIdRef.current
+      ? `/stories/${storyIdRef.current}`
+      : worldId ? `/worlds/${worldId}` : '/stories')
+  }, [navigate, worldId])
+
+  const handleBack = useCallback(() => {
+    if (isDirty()) {
+      setPendingNavigate(() => doNavigateBack)
+      setShowUnsavedModal(true)
+      return
+    }
+    doNavigateBack()
+  }, [isDirty, doNavigateBack])
+
+  const handleUnsavedSave = useCallback(async () => {
+    setShowUnsavedModal(false)
+    await doSave()
+    pendingNavigate?.()
+    setPendingNavigate(null)
+  }, [doSave, pendingNavigate])
+
+  const handleUnsavedDiscard = useCallback(() => {
+    setShowUnsavedModal(false)
+    pendingNavigate?.()
+    setPendingNavigate(null)
+  }, [pendingNavigate])
+
+  const handleUnsavedCancel = useCallback(() => {
+    setShowUnsavedModal(false)
+    setPendingNavigate(null)
+  }, [])
 
   const handlePublish = useCallback(async () => {
     if (!storyIdRef.current) await doSave()
@@ -216,12 +319,6 @@ function StoryEditorContainer({ showToast }) {
       showToast(t('pages.storyEditor.publishError'), 'error')
     }
   }, [doSave, showToast, t])
-
-  const handleBack = useCallback(() => {
-    navigate(storyIdRef.current
-      ? `/stories/${storyIdRef.current}`
-      : worldId ? `/worlds/${worldId}` : '/stories')
-  }, [navigate, worldId])
 
   const callGpt = useCallback(async (mode) => {
     const editorInstance = editorRef.current
@@ -260,15 +357,15 @@ function StoryEditorContainer({ showToast }) {
     setGpt(prev => ({ ...prev, suggestions: [] }))
   }, [])
 
-  const handleInsertSignature = useCallback(() => {
+  const handleInsertSignature = useCallback((sigText) => {
     const editorInstance = editorRef.current
-    if (!editorInstance || !userSignature) return
-    if (editorInstance.getText().includes(`— ${userSignature}`)) {
+    if (!editorInstance || !sigText) return
+    if (editorInstance.getText().includes(`— ${sigText}`)) {
       showToast(t('pages.storyEditor.signatureExists'), 'info')
       return
     }
-    editorInstance.chain().focus().insertContent(`<p>— ${userSignature}</p>`).run()
-  }, [userSignature, showToast, t])
+    editorInstance.chain().focus().insertContent(`<p>— ${sigText}</p>`).run()
+  }, [showToast, t])
 
   const gptProps = {
     ...gpt,
@@ -287,6 +384,7 @@ function StoryEditorContainer({ showToast }) {
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
       </Helmet>
+
       <StoryEditorView
         editor={editor}
         wordCount={wordCount}
@@ -295,16 +393,38 @@ function StoryEditorContainer({ showToast }) {
         editorRef={editorRef}
         gpt={gptProps}
         activeFormats={activeFormats}
-        userSignature={userSignature}
+        signatures={signatures}
+        showSignatureModal={showSignatureModal}
+        onOpenSignatureModal={() => setShowSignatureModal(true)}
+        onCloseSignatureModal={() => setShowSignatureModal(false)}
+        onSignaturesChange={setSignatures}
+        onInsertSignature={handleInsertSignature}
         onTitleChange={handleTitleChange}
         onContentUpdate={handleContentUpdate}
         onSelectionChange={handleSelectionChange}
         onSave={handleSave}
         onPublish={handlePublish}
         onBack={handleBack}
-        onInsertSignature={handleInsertSignature}
         initialFormat={initialFormat}
+        showToast={showToast}
       />
+
+      {showUnsavedModal && (
+        <UnsavedChangesModal
+          onSave={handleUnsavedSave}
+          onDiscard={handleUnsavedDiscard}
+          onCancel={handleUnsavedCancel}
+        />
+      )}
+
+      {showTitleModal && (
+        <TitleSuggestionModal
+          suggestion={titleSuggestion}
+          onConfirm={handleTitleModalConfirm}
+          onSkip={handleTitleModalSkip}
+          onCancel={() => setShowTitleModal(false)}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -285,6 +285,7 @@
       "signatureExists": "Signature already in document",
       "titlePlaceholder": "Story title…",
       "titleRequired": "Please enter a title",
+      "titleNoTitle": "(no title)",
       "back": "Back",
       "publish": "Publish",
       "save": "Save",
@@ -292,7 +293,25 @@
       "statusDraft": "Draft",
       "statusSaving": "Saving…",
       "statusSaved": "Saved",
-      "statusError": "Error"
+      "statusError": "Error",
+      "unsavedTitle": "Unsaved changes",
+      "unsavedMessage": "Would you like to save your draft or discard all changes?",
+      "saveDraft": "Save draft",
+      "discard": "Discard",
+      "titleSuggestTitle": "Save draft",
+      "titleSuggestMessage": "Give your story a title",
+      "titleSuggestPlaceholder": "Enter a title…",
+      "titleSuggestSkip": "Save without title"
+    },
+    "signatureModal": {
+      "title": "Signature",
+      "empty": "No signatures yet",
+      "manage": "Manage signatures",
+      "noSignature": "No signature",
+      "insert": "Insert",
+      "add": "Add",
+      "placeholder": "Author name or signature…",
+      "saveError": "Failed to save signatures"
     },
     "storyPrint": {
       "notFound": "Story not found.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -286,6 +286,7 @@
       "signatureExists": "Chữ ký đã có trong tài liệu",
       "titlePlaceholder": "Tiêu đề câu chuyện…",
       "titleRequired": "Vui lòng nhập tiêu đề",
+      "titleNoTitle": "(không tiêu đề)",
       "back": "Quay lại",
       "publish": "Xuất bản",
       "save": "Lưu",
@@ -293,7 +294,25 @@
       "statusDraft": "Nháp",
       "statusSaving": "Đang lưu…",
       "statusSaved": "Đã lưu",
-      "statusError": "Lỗi"
+      "statusError": "Lỗi",
+      "unsavedTitle": "Có thay đổi chưa lưu",
+      "unsavedMessage": "Bạn muốn lưu bản nháp hay bỏ hoàn toàn?",
+      "saveDraft": "Lưu nháp",
+      "discard": "Bỏ thay đổi",
+      "titleSuggestTitle": "Lưu bản nháp",
+      "titleSuggestMessage": "Đặt tiêu đề cho câu chuyện của bạn",
+      "titleSuggestPlaceholder": "Nhập tiêu đề…",
+      "titleSuggestSkip": "Lưu không có tiêu đề"
+    },
+    "signatureModal": {
+      "title": "Chữ ký",
+      "empty": "Chưa có chữ ký nào",
+      "manage": "Quản lý chữ ký",
+      "noSignature": "Chưa có chữ ký",
+      "insert": "Chèn",
+      "add": "Thêm",
+      "placeholder": "Tên tác giả hoặc chữ ký…",
+      "saveError": "Không thể lưu chữ ký"
     },
     "storyPrint": {
       "notFound": "Không tìm thấy câu chuyện.",


### PR DESCRIPTION
## Summary

- **Save without title**: autosave no longer blocks on empty title; falls back to `(no title)` so drafts are never lost mid-session
- **Unsaved changes warning**: back button + `beforeunload` both intercept with a modal — Save draft / Discard / Cancel
- **Title suggestion modal**: clicking Save with a blank title opens a modal pre-filled with text extracted from the first line of content; user can confirm, edit, or skip
- **Sticky header + Ctrl+S**: `EditorHeader` gets `sticky top-0 z-10` so title and Save stay visible on long docs; Ctrl/Cmd+S shortcut added
- **Signature modal**: replaces the dead single-button in LeftPanel with a full modal — list all saved signatures, insert into editor at cursor, add new, delete
- **Signatures backend**: `user.metadata.signatures[]` array stored and exposed via `/api/auth/me` (added `signature` + `signatures` to `_SAFE_METADATA_KEYS`); `PUT /api/auth/profile` accepts `signatures` array
- **Author signature token**: story creation auto-generates an immutable `author_signature.token` (UUID); `PATCH /api/stories/:id` can update `display` text but never changes the token; one token per story, owned by creator
- **Novel content format**: `NovelContentStream` renders via `marked.parse()` — markdown stories now display correctly instead of raw text
- **ThemeSelector tweak**: padding `p-2→p-4`, swatches `justify-start`, color picker always visible (removed custom-mode gate), language label `mb-2`

## New files
- `frontend/src/components/storyEditor/SignatureModal.jsx`
- `frontend/src/components/storyEditor/UnsavedChangesModal.jsx`
- `frontend/src/components/storyEditor/TitleSuggestionModal.jsx`

## Test plan
- [ ] Create a new story with no title → autosave fires → story saved as "(no title)"
- [ ] Click Save manually with blank title + some content → title suggestion modal appears
- [ ] Edit a story, click Back → unsaved changes modal appears; Save draft saves before navigating; Discard navigates without saving
- [ ] Refresh browser with unsaved changes → browser native unload warning fires
- [ ] Ctrl+S triggers save
- [ ] Open Signature panel → empty state; add a new signature; it appears in list; Insert inserts `— Name` into editor; Delete removes it
- [ ] Story creation in DB includes `author_signature.token` (check via API or Swagger); PATCH cannot change the token
- [ ] Novel view renders markdown headers/bold/lists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)