### PR TITLE
fix: logout modal invisible text and dropdown overlap

### DIFF
--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -52,7 +52,7 @@ export default function Modal({ open, onClose, title, children, className = '' }
             // shape: rounded top on mobile, rounded all on desktop
             'rounded-t-2xl sm:rounded-2xl',
             // colours & depth
-            'bg-base-100 shadow-2xl',
+            'bg-base-100 text-base-content shadow-2xl',
             // spacing
             'p-6',
             // height constraints

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -40,6 +40,10 @@ function Navbar() {
   const handleDeclineInvitation = handleInvitationAction(invitationsAPI.decline)
 
   const handleLogoutClick = () => {
+    // Close DaisyUI dropdown by blurring the active element
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
     setShowLogoutModal(true)
   }
 


### PR DESCRIPTION
## Summary

- **Invisible modal text**: The logout confirmation modal rendered inside the Navbar's `text-primary-content` context (white text), making the title and body invisible against `bg-base-100` (white background). Fixed by adding `text-base-content` to `Modal.jsx`'s card div so it resets the inherited text colour.
- **Dropdown stays open behind modal**: Clicking "Đăng xuất" in the DaisyUI dropdown opened the modal but left the dropdown visible behind it (DaisyUI dropdowns use `focus-within` so they stay open until focus moves). Fixed by calling `document.activeElement.blur()` in `handleLogoutClick` to collapse the dropdown first.

## Files changed

- `frontend/src/components/Modal.jsx` — add `text-base-content` to card classes
- `frontend/src/components/Navbar.jsx` — blur active element before opening modal

## Test plan

- [ ] Click the user avatar → "Đăng xuất" — confirm the dropdown closes and the modal appears with visible title ("Xác nhận đăng xuất") and body text
- [ ] Click "Hủy" — modal dismisses, no logout
- [ ] Click "Đăng xuất" in the modal — logs out successfully
- [ ] Verify the same behaviour in light and dark themes (text must be readable in both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)