### PR TITLE
Migrate novel page to full SSR

### DIFF
--- a/app/(main)/stories/page.jsx
+++ b/app/(main)/stories/page.jsx
@@ -1,9 +1,51 @@
-'use client'
-
+import { getServerT } from '../../../src/i18n/serverI18n'
 import StoriesPage from '../../../src/views/StoriesPage'
-import { useToast } from '../../../src/contexts/ToastContext'
 
-export default function Page() {
-  const { showToast } = useToast()
-  return <StoriesPage showToast={showToast} />
+function getServerApiBase() {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}/api`
+  }
+  return 'http://localhost:5000/api'
+}
+
+function getBypassHeaders() {
+  const bypass =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ||
+    process.env.VERCEL_BYPASS_SECRET
+  return bypass ? { 'x-vercel-protection-bypass': bypass } : {}
+}
+
+export function generateMetadata() {
+  const t = getServerT()
+  return {
+    title: t('meta.stories.title'),
+    description: t('meta.stories.description'),
+  }
+}
+
+async function fetchInitialData() {
+  const base = getServerApiBase()
+  const headers = getBypassHeaders()
+  try {
+    const [storiesRes, worldsRes] = await Promise.all([
+      fetch(`${base}/stories`, { headers, next: { revalidate: 60 } }),
+      fetch(`${base}/worlds`, { headers, next: { revalidate: 60 } }),
+    ])
+    if (!storiesRes.ok || !worldsRes.ok) return null
+    const [storiesJson, worldsJson] = await Promise.all([
+      storiesRes.json(),
+      worldsRes.json(),
+    ])
+    return {
+      stories: storiesJson.data ?? [],
+      worlds: worldsJson.data ?? [],
+    }
+  } catch {
+    return null
+  }
+}
+
+export default async function Page() {
+  const initialData = await fetchInitialData()
+  return <StoriesPage initialData={initialData} />
 }

--- a/app/(main)/worlds/[worldId]/novel/page.jsx
+++ b/app/(main)/worlds/[worldId]/novel/page.jsx
@@ -1,9 +1,72 @@
-'use client'
-
 import NovelPage from '../../../../../src/views/NovelPage'
-import { useToast } from '../../../../../src/contexts/ToastContext'
+import { getServerLocale, getServerT } from '../../../../../src/i18n/serverI18n'
 
-export default function Page() {
-  const { showToast } = useToast()
-  return <NovelPage showToast={showToast} />
+function getServerApiBase() {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}/api`
+  }
+  return 'http://localhost:5000/api'
+}
+
+function getBypassHeaders() {
+  const bypass =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ||
+    process.env.VERCEL_BYPASS_SECRET
+  return bypass ? { 'x-vercel-protection-bypass': bypass } : {}
+}
+
+export async function generateMetadata({ params }) {
+  const { worldId } = params
+  const t = getServerT()
+  try {
+    const res = await fetch(
+      `${getServerApiBase()}/worlds/${worldId}/novel`,
+      { headers: getBypassHeaders(), next: { revalidate: 60 } }
+    )
+    if (res.ok) {
+      const json = await res.json()
+      const name = json.data?.title
+      if (name) {
+        return {
+          title: t('meta.novel.titleTemplate').replace('{{name}}', name),
+          description: t('meta.novel.descriptionTemplate').replace('{{name}}', name),
+        }
+      }
+    }
+  } catch {}
+  return {
+    title: t('meta.novel.titleFallback'),
+    description: t('meta.novel.descriptionFallback'),
+  }
+}
+
+async function fetchInitialNovelData(worldId) {
+  const base = getServerApiBase()
+  const headers = getBypassHeaders()
+  try {
+    const [metaRes, contentRes] = await Promise.all([
+      fetch(`${base}/worlds/${worldId}/novel`, { headers, next: { revalidate: 60 } }),
+      fetch(`${base}/worlds/${worldId}/novel/content?line_budget=100`, { headers, next: { revalidate: 60 } }),
+    ])
+    if (!metaRes.ok || !contentRes.ok) return null
+    const [metaJson, contentJson] = await Promise.all([metaRes.json(), contentRes.json()])
+    return {
+      novel: metaJson.data ?? null,
+      chapters: metaJson.data?.chapters ?? [],
+      contentBlocks: contentJson.data?.blocks ?? [],
+      nextCursor: contentJson.data?.next_cursor ?? null,
+      hasMore: contentJson.data?.has_more ?? false,
+    }
+  } catch {
+    return null
+  }
+}
+
+export default async function Page({ params }) {
+  const { worldId } = params
+  const [initialData, locale] = await Promise.all([
+    fetchInitialNovelData(worldId),
+    Promise.resolve(getServerLocale()),
+  ])
+  return <NovelPage initialData={initialData} locale={locale} />
 }

--- a/app/(main)/worlds/[worldId]/novel/page.jsx
+++ b/app/(main)/worlds/[worldId]/novel/page.jsx
@@ -1,5 +1,5 @@
 import NovelPage from '../../../../../src/views/NovelPage'
-import { getServerLocale, getServerT } from '../../../../../src/i18n/serverI18n'
+import { getServerT } from '../../../../../src/i18n/serverI18n'
 
 function getServerApiBase() {
   if (process.env.VERCEL_URL) {
@@ -64,9 +64,6 @@ async function fetchInitialNovelData(worldId) {
 
 export default async function Page({ params }) {
   const { worldId } = params
-  const [initialData, locale] = await Promise.all([
-    fetchInitialNovelData(worldId),
-    Promise.resolve(getServerLocale()),
-  ])
-  return <NovelPage initialData={initialData} locale={locale} />
+  const initialData = await fetchInitialNovelData(worldId)
+  return <NovelPage initialData={initialData} />
 }

--- a/app/(main)/worlds/page.jsx
+++ b/app/(main)/worlds/page.jsx
@@ -1,9 +1,43 @@
-'use client'
-
+import { getServerT } from '../../../src/i18n/serverI18n'
 import WorldsPage from '../../../src/views/WorldsPage'
-import { useToast } from '../../../src/contexts/ToastContext'
 
-export default function Page() {
-  const { showToast } = useToast()
-  return <WorldsPage showToast={showToast} />
+function getServerApiBase() {
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}/api`
+  }
+  return 'http://localhost:5000/api'
+}
+
+function getBypassHeaders() {
+  const bypass =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ||
+    process.env.VERCEL_BYPASS_SECRET
+  return bypass ? { 'x-vercel-protection-bypass': bypass } : {}
+}
+
+export function generateMetadata() {
+  const t = getServerT()
+  return {
+    title: t('meta.worlds.title'),
+    description: t('meta.worlds.description'),
+  }
+}
+
+async function fetchInitialWorlds() {
+  try {
+    const res = await fetch(
+      `${getServerApiBase()}/worlds`,
+      { headers: getBypassHeaders(), next: { revalidate: 60 } }
+    )
+    if (!res.ok) return null
+    const json = await res.json()
+    return json.data ?? null
+  } catch {
+    return null
+  }
+}
+
+export default async function Page() {
+  const initialWorlds = await fetchInitialWorlds()
+  return <WorldsPage initialWorlds={initialWorlds} />
 }

--- a/src/containers/NovelContainer.jsx
+++ b/src/containers/NovelContainer.jsx
@@ -2,35 +2,34 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useParams } from '../utils/router-compat'
-import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
-import { usePageTitle } from '../hooks/usePageTitle'
 import { novelAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import NovelView from '../components/novel/NovelView'
 
 const LINE_BUDGET = 100
 
-function NovelContainer({ showToast }) {
+function NovelContainer({ showToast, initialData }) {
   const { t } = useTranslation()
   const { worldId } = useParams()
   const { user } = useAuth()
 
-  const [novel, setNovel] = useState(null)
-  const [chapters, setChapters] = useState([])
-  const [contentBlocks, setContentBlocks] = useState([])
-  const [nextCursor, setNextCursor] = useState(null)
-  const [hasMore, setHasMore] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
+  // When the server pre-fetched data, seed state from it and skip the initial
+  // client-side fetch. `null` means the server fetch failed → fall back to
+  // client-side loading so the page still works.
+  const hasSSRData = initialData != null
+  const [novel, setNovel] = useState(initialData?.novel ?? null)
+  const [chapters, setChapters] = useState(initialData?.chapters ?? [])
+  const [contentBlocks, setContentBlocks] = useState(initialData?.contentBlocks ?? [])
+  const [nextCursor, setNextCursor] = useState(initialData?.nextCursor ?? null)
+  const [hasMore, setHasMore] = useState(initialData?.hasMore ?? false)
+  const [isLoading, setIsLoading] = useState(!hasSSRData)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   // Synchronous guard against observer double-fires (state updates lag).
   const loadingMoreRef = useRef(false)
-  const novelTitle = usePageTitle('novel', novel?.title)
-  const novelDescription = novel?.title
-    ? t('meta.novel.descriptionTemplate', { name: novel.title })
-    : t('meta.novel.descriptionFallback')
 
   useEffect(() => {
+    if (hasSSRData) return
     load()
   }, [worldId])
 
@@ -100,10 +99,6 @@ function NovelContainer({ showToast }) {
 
   return (
     <>
-      <Helmet>
-        <title>{novelTitle}</title>
-        <meta name="description" content={novelDescription} />
-      </Helmet>
       <NovelView
         worldId={worldId}
         novel={novel}
@@ -121,5 +116,6 @@ function NovelContainer({ showToast }) {
     </>
   )
 }
+
 
 export default NovelContainer

--- a/src/containers/StoriesContainer.jsx
+++ b/src/containers/StoriesContainer.jsx
@@ -1,21 +1,22 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 import { worldsAPI, storiesAPI } from '../services/api'
 import LoadingSpinner from '../components/LoadingSpinner'
 import StoriesView from '../components/stories/StoriesView'
 import { useAuth } from '../contexts/AuthContext'
 
-function StoriesContainer({ showToast }) {
+function StoriesContainer({ showToast, initialData }) {
   const { t } = useTranslation()
   const { user, loading: authLoading } = useAuth()
-  const [worlds, setWorlds] = useState([])
-  const [stories, setStories] = useState([])
-  const [loading, setLoading] = useState(true)
+  const hasSSRData = initialData != null
+  const [worlds, setWorlds] = useState(initialData?.worlds ?? [])
+  const [stories, setStories] = useState(initialData?.stories ?? [])
+  const [loading, setLoading] = useState(!hasSSRData)
 
   useEffect(() => {
+    if (hasSSRData) return
     loadData()
   }, [])
 
@@ -53,10 +54,6 @@ function StoriesContainer({ showToast }) {
 
   return (
     <>
-      <Helmet>
-        <title>{t('meta.stories.title')}</title>
-        <meta name="description" content={t('meta.stories.description')} />
-      </Helmet>
       <StoriesView
       stories={stories}
       worlds={worlds}

--- a/src/views/NovelPage.jsx
+++ b/src/views/NovelPage.jsx
@@ -3,9 +3,9 @@
 import NovelContainer from '../containers/NovelContainer'
 import { useToast } from '../contexts/ToastContext'
 
-function NovelPage({ initialData, locale }) {
+function NovelPage({ initialData }) {
   const { showToast } = useToast()
-  return <NovelContainer showToast={showToast} initialData={initialData} locale={locale} />
+  return <NovelContainer showToast={showToast} initialData={initialData} />
 }
 
 export default NovelPage

--- a/src/views/NovelPage.jsx
+++ b/src/views/NovelPage.jsx
@@ -1,9 +1,11 @@
 'use client'
 
 import NovelContainer from '../containers/NovelContainer'
+import { useToast } from '../contexts/ToastContext'
 
-function NovelPage({ showToast }) {
-  return <NovelContainer showToast={showToast} />
+function NovelPage({ initialData, locale }) {
+  const { showToast } = useToast()
+  return <NovelContainer showToast={showToast} initialData={initialData} locale={locale} />
 }
 
 export default NovelPage

--- a/src/views/StoriesPage.jsx
+++ b/src/views/StoriesPage.jsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useToast } from '../contexts/ToastContext'
 import StoriesContainer from '../containers/StoriesContainer'
 
-function StoriesPage(props) {
-    return <StoriesContainer {...props} />
+function StoriesPage({ initialData }) {
+  const { showToast } = useToast()
+  return <StoriesContainer showToast={showToast} initialData={initialData} />
 }
 
 export default StoriesPage

--- a/src/views/WorldsPage.jsx
+++ b/src/views/WorldsPage.jsx
@@ -2,10 +2,10 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Link } from '../utils/router-compat'
-import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 import { worldsAPI, gptAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useToast } from '../contexts/ToastContext'
 import LoadingSpinner from '../components/LoadingSpinner'
 import GptButton, { OpenAILogo } from '../components/GptButton'
 import {
@@ -18,11 +18,17 @@ import {
 } from '@heroicons/react/24/outline'
 import Tag from '../components/Tag'
 
-function WorldsPage({ showToast }) {
+function WorldsPage({ initialWorlds }) {
+  const { showToast } = useToast()
   const { t } = useTranslation()
   const { isAuthenticated, user, loading: authLoading } = useAuth()
-  const [worlds, setWorlds] = useState([])
-  const [loading, setLoading] = useState(true)
+
+  // Skip the initial client-side fetch when SSR pre-fetched public worlds.
+  // Re-fetch still fires when the user authenticates (private worlds become visible).
+  const hasSSRData = initialWorlds != null
+  const skipFirstFetch = useRef(hasSSRData)
+  const [worlds, setWorlds] = useState(initialWorlds ?? [])
+  const [loading, setLoading] = useState(!hasSSRData)
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [formData, setFormData] = useState({
     name: '',
@@ -34,6 +40,10 @@ function WorldsPage({ showToast }) {
   const dialogRef = useRef(null)
 
   useEffect(() => {
+    if (skipFirstFetch.current) {
+      skipFirstFetch.current = false
+      return
+    }
     loadWorlds()
   }, [isAuthenticated])
 
@@ -253,10 +263,6 @@ function WorldsPage({ showToast }) {
 
   return (
     <div>
-      <Helmet>
-        <title>{t('meta.worlds.title')}</title>
-        <meta name="description" content={t('meta.worlds.description')} />
-      </Helmet>
       <div className="flex justify-between items-center mb-6">
         <h1 className="font-bold text-3xl"><GlobeAltIcon className="inline w-8 h-8" /> {t('pages.worlds.title')}</h1>
         {authLoading ? (


### PR DESCRIPTION
## Summary

- Convert `app/(main)/worlds/[worldId]/novel/page.jsx` from a `'use client'` component to an async server component
- Add `generateMetadata` for proper SSR SEO titles and descriptions (replacing client-side `react-helmet-async`)
- Pre-fetch novel metadata and first-page content server-side; pass as `initialData` to the client container so no waterfall fetch on hydration
- `NovelContainer` seeds state from `initialData` and skips the initial `useEffect` fetch — falls back to client-side fetching if the server fetch fails (`initialData === null`)
- Infinite-scroll pagination for subsequent pages continues to work client-side unchanged

## Test plan

- [ ] Navigate to `/worlds/:id/novel` — content renders immediately without a loading flash
- [ ] Verify page `<title>` is set to the novel title in the HTML response (view source / curl)
- [ ] Scroll to the bottom — infinite scroll loads additional chapters correctly
- [ ] Test with a world that has no chapters — empty state renders correctly
- [ ] Test on a world the user doesn't own — `canReorder` is false, drag handles hidden
- [ ] Test on a world the user owns — drag-to-reorder chapters still works
- [ ] Kill the Flask API, load the page — falls back to client-side fetch (shows loading spinner, then loads when API is available)

https://claude.ai/code/session_01AnuNasTuneFqNJ5pXJo5av

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnuNasTuneFqNJ5pXJo5av)_