### PR TITLE
feat: gate GPT features behind explicit per-user whitelist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- 
+- 
+- 
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `` |  |
+
+## Test plan
+
+- [ ] 
+- [ ] 
+- [ ] 

--- a/api/core/models/user.py
+++ b/api/core/models/user.py
@@ -63,6 +63,8 @@ class User:
             self.metadata['gpt_requests_today'] = 0
         if 'gpt_last_reset' not in self.metadata:
             self.metadata['gpt_last_reset'] = datetime.utcnow().date().isoformat()
+        if 'gpt_enabled' not in self.metadata:
+            self.metadata['gpt_enabled'] = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert User to dictionary."""
@@ -86,6 +88,7 @@ class User:
         'public_worlds_count',
         'public_stories_limit',
         'public_stories_count',
+        'gpt_enabled',
         'gpt_requests_per_day',
         'gpt_requests_today',
         'gpt_last_reset',
@@ -148,6 +151,10 @@ class User:
     def can_use_gpt(self) -> bool:
         """Check if user can use GPT (within daily quota)."""
         from core.permissions import has_permission, Permission
+
+        # Explicit whitelist gate — must be enabled per-user regardless of role
+        if not self.metadata.get('gpt_enabled', False):
+            return False
 
         # Check if unlimited GPT
         if has_permission(self.role, Permission.USE_GPT_UNLIMITED):

--- a/api/interfaces/auth_middleware.py
+++ b/api/interfaces/auth_middleware.py
@@ -64,7 +64,8 @@ def token_required(f):
                         email=payload.get('email', ''),
                         password_hash='',
                         role=payload.get('role', 'user'),
-                        user_id=payload.get('user_id')
+                        user_id=payload.get('user_id'),
+                        metadata={'gpt_enabled': payload.get('gpt_enabled', False)}
                     )
                     logger.info(f"Using token payload fallback for user: {payload.get('username')}")
                 else:
@@ -155,7 +156,8 @@ def optional_auth(f):
                             email=payload.get('email', ''),
                             password_hash='',
                             role=payload.get('role', 'user'),
-                            user_id=payload.get('user_id')
+                            user_id=payload.get('user_id'),
+                            metadata={'gpt_enabled': payload.get('gpt_enabled', False)}
                         )
                         logger.info(f"Using token payload fallback for user: {payload.get('username')}")
             except Exception as e:

--- a/api/interfaces/routes/admin_routes.py
+++ b/api/interfaces/routes/admin_routes.py
@@ -173,6 +173,53 @@ def create_admin_bp(storage, auth_service):
             }
         }, t('admin.role_changed', old_role=old_role, new_role=new_role))
 
+    @admin_bp.route('/api/admin/users/<user_id>/gpt-access', methods=['PUT'])
+    @token_required
+    @admin_required
+    def set_user_gpt_access(user_id):
+        """Enable or disable GPT access for a user (admin only).
+        ---
+        tags:
+          - Admin
+        parameters:
+          - in: path
+            name: user_id
+            type: string
+            required: true
+          - in: body
+            name: body
+            required: true
+            schema:
+              type: object
+              required:
+                - enabled
+              properties:
+                enabled:
+                  type: boolean
+        responses:
+          200:
+            description: GPT access updated
+          404:
+            description: User not found
+        """
+        data = request.get_json(silent=True) or {}
+        enabled = data.get('enabled')
+        if not isinstance(enabled, bool):
+            from core.exceptions import ValidationError
+            raise ValidationError('enabled must be a boolean')
+
+        user_data = storage.load_user(user_id)
+        if not user_data:
+            raise ResourceNotFoundError('User', user_id)
+
+        user_data.setdefault('metadata', {})['gpt_enabled'] = enabled
+        storage.save_user(user_data)
+
+        return success_response({
+            'user_id': user_id,
+            'gpt_enabled': enabled
+        }, f"GPT access {'enabled' if enabled else 'disabled'} for user")
+
     @admin_bp.route('/api/admin/users/<user_id>/ban', methods=['POST'])
     @token_required
     @moderator_required

--- a/api/interfaces/routes/gpt_routes.py
+++ b/api/interfaces/routes/gpt_routes.py
@@ -1,12 +1,13 @@
 """GPT routes for the API backend."""
 
 import logging
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, g
 from core.exceptions import (
     ResourceNotFoundError,
     ValidationError as APIValidationError,
     ExternalServiceError,
-    BusinessRuleError
+    BusinessRuleError,
+    PermissionDeniedError,
 )
 from utils.responses import success_response
 from utils.validation import validate_request
@@ -90,6 +91,9 @@ def create_gpt_bp(backend, gpt_results, storage=None, flush_data=None, limiter=N
           503:
             description: GPT not available
         """
+        if not g.current_user.can_use_gpt():
+            raise PermissionDeniedError('use_gpt', 'feature')
+
         backend._ensure_gpt()
         if not backend.has_gpt:
             raise ExternalServiceError('GPT', 'GPT not available')
@@ -246,6 +250,9 @@ def create_gpt_bp(backend, gpt_results, storage=None, flush_data=None, limiter=N
           503:
             description: GPT not available
         """
+        if not g.current_user.can_use_gpt():
+            raise PermissionDeniedError('use_gpt', 'feature')
+
         backend._ensure_gpt()
         if not backend.has_gpt:
             raise ExternalServiceError('GPT', 'GPT not available')
@@ -350,6 +357,9 @@ def create_gpt_bp(backend, gpt_results, storage=None, flush_data=None, limiter=N
           503:
             description: GPT not available
         """
+        if not g.current_user.can_use_gpt():
+            raise PermissionDeniedError('use_gpt', 'feature')
+
         backend._ensure_gpt()
         if not backend.has_gpt:
             raise ExternalServiceError('GPT', 'GPT not available')
@@ -483,6 +493,9 @@ def create_gpt_bp(backend, gpt_results, storage=None, flush_data=None, limiter=N
           429:
             description: Quota exceeded
         """
+        if not g.current_user.can_use_gpt():
+            raise PermissionDeniedError('use_gpt', 'feature')
+
         data = request.validated_data
         text = data['text']
         mode = data.get('mode', 'paraphrase')

--- a/api/services/auth_service.py
+++ b/api/services/auth_service.py
@@ -121,6 +121,7 @@ class AuthService:
             'username': user.username,
             'email': user.email,
             'role': user.role,
+            'gpt_enabled': user.metadata.get('gpt_enabled', False),
             'exp': expiry_time,
             'iat': datetime.utcnow()
         }

--- a/e2e/global-setup.cjs
+++ b/e2e/global-setup.cjs
@@ -48,6 +48,43 @@ module.exports = async function globalSetup(config) {
       console.error('[global-setup] admin login failed — tests will likely fail')
     }
 
+    // Enable GPT access for testuser so GPT button E2E tests can pass
+    if (loginRes.ok()) {
+      const adminToken = (await loginRes.json()).token
+      const adminCtx = await request.newContext({
+        baseURL,
+        extraHTTPHeaders: {
+          ...extraHeaders,
+          Authorization: `Bearer ${adminToken}`,
+        },
+      })
+      try {
+        // Look up testuser's ID via the admin users list
+        const usersRes = await adminCtx.get('/api/admin/users?search=testuser')
+        if (usersRes.ok()) {
+          const usersData = await usersRes.json()
+          const testUser = (usersData.data || usersData.users || []).find(
+            (u) => u.username === 'testuser'
+          )
+          if (testUser) {
+            const gptRes = await adminCtx.put(
+              `/api/admin/users/${testUser.user_id}/gpt-access`,
+              { data: { enabled: true } }
+            )
+            if (gptRes.ok()) {
+              console.log('[global-setup] testuser GPT access enabled ✓')
+            } else {
+              console.warn(`[global-setup] failed to enable GPT for testuser: ${gptRes.status()}`)
+            }
+          } else {
+            console.warn('[global-setup] testuser not found in admin users list')
+          }
+        }
+      } finally {
+        await adminCtx.dispose()
+      }
+    }
+
     // Warm up the Vercel Python lambda before tests start.
     // A cold-start can take 5-15 s; hitting /api/health forces the instance
     // to finish initialising so the first storyEditor test's API calls

--- a/e2e/storyEditor.spec.cjs
+++ b/e2e/storyEditor.spec.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const { test, expect } = require('@playwright/test')
-const { login } = require('./utils/auth.cjs')
+const { login, TEST_USER } = require('./utils/auth.cjs')
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -39,7 +39,7 @@ test.describe('Story Editor', () => {
   let worldId
 
   test.beforeEach(async ({ page }) => {
-    await login(page)
+    await login(page, TEST_USER)
     worldId = await ensureWorld(page)
     await openEditor(page, worldId)
   })

--- a/src/components/storyEditor/GptToolsPanel.jsx
+++ b/src/components/storyEditor/GptToolsPanel.jsx
@@ -8,12 +8,13 @@ function GptToolsPanel({
   selectionLength,
   isLoading,
   suggestions,
+  userCanUseGpt,
   onParaphrase,
   onExpand,
   onApply,
   onClear,
 }) {
-  const canUseGpt = selectionLength >= 10
+  const canUseGpt = userCanUseGpt && selectionLength >= 10
   const [previewIdx, setPreviewIdx] = useState(null)
 
   function closePreview() {
@@ -50,7 +51,12 @@ function GptToolsPanel({
         </button>
       </div>
 
-      {!canUseGpt && (
+      {!userCanUseGpt && (
+        <p className="text-xs text-base-content/40 italic">
+          Tính năng GPT chưa được kích hoạt cho tài khoản của bạn
+        </p>
+      )}
+      {userCanUseGpt && !canUseGpt && (
         <p className="text-xs text-base-content/40 italic">
           Chọn ≥ 10 ký tự để sử dụng
         </p>

--- a/src/components/storyEditor/GptToolsPanel.jsx
+++ b/src/components/storyEditor/GptToolsPanel.jsx
@@ -14,7 +14,7 @@ function GptToolsPanel({
   onApply,
   onClear,
 }) {
-  const canUseGpt = userCanUseGpt && selectionLength >= 10
+  const canUseGpt = (userCanUseGpt ?? false) && selectionLength >= 10
   const [previewIdx, setPreviewIdx] = useState(null)
 
   function closePreview() {

--- a/src/containers/StoryEditorContainer.jsx
+++ b/src/containers/StoryEditorContainer.jsx
@@ -26,7 +26,7 @@ function StoryEditorContainer({ showToast }) {
   const { storyId } = useParams()
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
-  const { user, loading: authLoading } = useAuth()
+  const { user, loading: authLoading, canUseGpt } = useAuth()
 
   const worldId = searchParams.get('worldId')
 
@@ -370,6 +370,7 @@ function StoryEditorContainer({ showToast }) {
 
   const gptProps = {
     ...gpt,
+    userCanUseGpt: canUseGpt,
     onParaphrase: handleParaphrase,
     onExpand: handleExpand,
     onApply: handleApply,

--- a/src/containers/WorldDetailContainer.jsx
+++ b/src/containers/WorldDetailContainer.jsx
@@ -16,7 +16,7 @@ const STORIES_PER_PAGE = 20
 function WorldDetailContainer({ showToast }) {
   const { t } = useTranslation()
   const { worldId } = useParams()
-  const { user, loading: authLoading } = useAuth()
+  const { user, loading: authLoading, canUseGpt } = useAuth()
   const { registerTask } = useGptTasks()
   const [world, setWorld] = useState(null)
   const [stories, setStories] = useState([])
@@ -141,6 +141,10 @@ function WorldDetailContainer({ showToast }) {
   const handleBatchAnalyze = async (storyIds) => {
     if (!user) {
       showToast(t('pages.worldDetail.loginRequired'), 'warning')
+      return
+    }
+    if (!canUseGpt) {
+      showToast(t('pages.worldDetail.gptNotEnabled', { defaultValue: 'Tính năng GPT chưa được kích hoạt cho tài khoản của bạn' }), 'warning')
       return
     }
     try {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -174,6 +174,7 @@ export const AuthProvider = ({ children }) => {
     token,
     loading,
     isAuthenticated: !!user,
+    canUseGpt: user?.metadata?.gpt_enabled === true,
     login,
     register,
     logout,


### PR DESCRIPTION
## Summary

- Add a `gpt_enabled` boolean field (default `False`) to every user's metadata — the explicit whitelist gate
- All four GPT mutation endpoints now check `g.current_user.can_use_gpt()` and return **403** if the flag is not set; guests get **401** via the existing `@token_required`
- Frontend reads `user.metadata.gpt_enabled` from `AuthContext` and exposes `canUseGpt`; GPT buttons in the story editor are disabled and show an "account not enabled" message; batch-analyze in the world detail view bails early with a toast

## What changed

| File | Change |
|------|--------|
| `api/core/models/user.py` | Initialize `gpt_enabled: False`; add to safe-metadata whitelist; `can_use_gpt()` short-circuits on `False` |
| `api/interfaces/routes/gpt_routes.py` | Import `g`, `PermissionDeniedError`; add `can_use_gpt()` guard to `generate-description`, `analyze`, `batch-analyze-stories`, `paraphrase` |
| `src/contexts/AuthContext.jsx` | Expose `canUseGpt: user?.metadata?.gpt_enabled === true` |
| `src/containers/StoryEditorContainer.jsx` | Read `canUseGpt`; pass as `userCanUseGpt` in `gptProps` |
| `src/components/storyEditor/GptToolsPanel.jsx` | Gate buttons on `userCanUseGpt`; show account-level vs selection-level hints separately |
| `src/containers/WorldDetailContainer.jsx` | Block `handleBatchAnalyze` with a toast when `!canUseGpt` |

## How to whitelist a user

Set `metadata.gpt_enabled = true` in MongoDB for the target user document. No role change required.

## Test plan

- [ ] Unauthenticated request to any `/api/gpt/*` mutation → 401
- [ ] Authenticated user with `gpt_enabled: false` → 403 on all mutation endpoints
- [ ] Authenticated user with `gpt_enabled: true` → normal GPT flow
- [ ] Story editor: GPT buttons disabled + "account not enabled" hint for non-whitelisted users
- [ ] World detail: batch-analyze shows warning toast for non-whitelisted users
- [ ] Existing whitelisted (premium/moderator) users unaffected once `gpt_enabled` is set to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)