### PR TITLE
feat: branded 404 and 500 error pages with theme support

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -159,37 +159,79 @@ jobs:
 
             // Parse Playwright JSON results for failed test details.
             // Suites can nest (file-suite → describe-suite → specs), so walk
-            // the tree recursively instead of looking only two levels deep.
-            let failedLines = ''
+            // the tree recursively, collecting full breadcrumb paths.
+            let failedSection = ''
             const resultsPath = 'test-results/results.json'
             if (!fs.existsSync(resultsPath)) {
-              failedLines = [
-                '_No `test-results/results.json` was produced — the Playwright step likely did not run._',
-                '_Common cause: the "Wait for deployment to be reachable" step failed (e.g. Vercel Deployment Protection is blocking). Check the job log for details._',
-              ].join('\n\n')
+              failedSection = [
+                '### ⚙️ Setup step failed — no tests ran',
+                '',
+                'The Playwright test runner never started. Most common causes:',
+                '',
+                '| Symptom | Fix |',
+                '|---------|-----|',
+                '| `HTTP 401` / `403` in job log | `VERCEL_AUTOMATION_BYPASS_SECRET` is missing or wrong in GitHub Secrets |',
+                '| `HTTP 000` / curl error | Deployment URL unreachable / DNS not propagated yet |',
+                '| Browser install error | Run `npx playwright install` in the workflow before tests |',
+                '',
+                '**Steps to fix the bypass secret:**',
+                '1. Vercel → Project → Settings → Deployment Protection → copy the _Protection Bypass for Automation_ token',
+                '2. GitHub repo → Settings → Secrets → Actions → update `VERCEL_AUTOMATION_BYPASS_SECRET`',
+                '',
+                '> Check the **"Wait for deployment to be reachable"** step in the [job log](' + runUrl + ') for the exact HTTP status.',
+              ].join('\n')
             } else {
               try {
                 const raw = fs.readFileSync(resultsPath, 'utf8')
                 const report = JSON.parse(raw)
                 const BAD_STATUSES = new Set(['failed', 'timedOut', 'interrupted'])
                 const failures = []
-                const walk = (suite) => {
+
+                // Walk suite tree, building a readable breadcrumb path per spec.
+                const walk = (suite, crumbs = []) => {
+                  const trail = suite.title ? [...crumbs, suite.title] : crumbs
                   for (const spec of (suite.specs || [])) {
-                    const bad = (spec.tests || []).flatMap(t => t.results || []).filter(r => BAD_STATUSES.has(r.status))
+                    const bad = (spec.tests || [])
+                      .flatMap(t => t.results || [])
+                      .filter(r => BAD_STATUSES.has(r.status))
                     if (!bad.length) continue
                     const worst = bad[0]
-                    const label = worst.status === 'timedOut' ? '⏱ timeout' : '❌ failed'
-                    const err = worst.error?.message?.split('\n')[0] || worst.status
-                    failures.push(`| \`${spec.title}\` | ${label} | ${err.slice(0, 120)} |`)
+                    failures.push({
+                      path: [...trail, spec.title].join(' › '),
+                      status: worst.status,
+                      duration: worst.duration ?? 0,
+                      message: worst.error?.message || worst.status,
+                      stack: worst.error?.stack || '',
+                    })
                   }
-                  for (const child of (suite.suites || [])) walk(child)
+                  for (const child of (suite.suites || [])) walk(child, trail)
                 }
                 for (const suite of (report.suites || [])) walk(suite)
-                failedLines = failures.length
-                  ? `| Test | Status | Error |\n|------|--------|-------|\n${failures.join('\n')}`
-                  : '_Job failed but no individual test was marked as failed — the wait/setup step likely failed. Check the job log._'
+
+                if (failures.length === 0) {
+                  failedSection = [
+                    '### ⚙️ Setup step failed — no tests ran',
+                    '',
+                    '_Job failed but no individual test was marked as failed.',
+                    'The wait/setup step most likely failed before Playwright started — check the [job log](' + runUrl + ')._',
+                  ].join('\n')
+                } else {
+                  const icon = s => s === 'timedOut' ? '⏱️ timed out' : s === 'interrupted' ? '🚫 interrupted' : '❌ failed'
+                  const blocks = failures.map(({ path, status, duration, message, stack }) => {
+                    const secs = duration ? ` _(${(duration / 1000).toFixed(1)}s)_` : ''
+                    // Full error message in a code block (capped at 800 chars)
+                    const msgBlock = '```\n' + message.slice(0, 800) + (message.length > 800 ? '\n…(truncated)' : '') + '\n```'
+                    // Stack trace in a collapsible block, strip redundant first line if dupe of message
+                    const stackBody = stack.replace(/^.+\n/, '').trim()
+                    const stackBlock = stackBody
+                      ? '<details>\n<summary>Stack trace</summary>\n\n```\n' + stackBody.slice(0, 1500) + (stackBody.length > 1500 ? '\n…(truncated)' : '') + '\n```\n\n</details>'
+                      : ''
+                    return [`**\`${path}\`** — ${icon(status)}${secs}`, '', msgBlock, stackBlock].filter(Boolean).join('\n')
+                  })
+                  failedSection = `### ❌ ${failures.length} test(s) failed\n\n---\n\n` + blocks.join('\n\n---\n\n')
+                }
               } catch (e) {
-                failedLines = `_Could not parse \`test-results/results.json\`: ${e.message}_`
+                failedSection = `_Could not parse \`test-results/results.json\`: ${e.message}_`
               }
             }
 
@@ -200,10 +242,9 @@ jobs:
               `**Deploy:** ${deployUrl}`,
               `**Run:** [Logs & artifacts](${runUrl})`,
               '',
-              '### Failed tests',
-              failedLines,
+              failedSection,
               '',
-              '> Screenshots and videos are attached as artifacts on the Actions run.',
+              '> 📎 Screenshots and videos are attached as artifacts on the Actions run.',
             ].join('\n')
 
             // Delete all previous failure comments from this workflow so

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -185,6 +185,9 @@ jobs:
                 const raw = fs.readFileSync(resultsPath, 'utf8')
                 const report = JSON.parse(raw)
                 const BAD_STATUSES = new Set(['failed', 'timedOut', 'interrupted'])
+                // Strip ANSI escape codes (colour, dim, bold, etc.) that
+                // Playwright embeds in error messages and call logs.
+                const stripAnsi = s => s.replace(/\[[0-9;]*m/g, '')
                 const failures = []
 
                 // Walk suite tree, building a readable breadcrumb path per spec.
@@ -200,8 +203,8 @@ jobs:
                       path: [...trail, spec.title].join(' › '),
                       status: worst.status,
                       duration: worst.duration ?? 0,
-                      message: worst.error?.message || worst.status,
-                      stack: worst.error?.stack || '',
+                      message: stripAnsi(worst.error?.message || worst.status),
+                      stack: stripAnsi(worst.error?.stack || ''),
                     })
                   }
                   for (const child of (suite.suites || [])) walk(child, trail)

--- a/app/(main)/worlds/[worldId]/novel/page.jsx
+++ b/app/(main)/worlds/[worldId]/novel/page.jsx
@@ -1,3 +1,4 @@
+import { notFound } from 'next/navigation'
 import NovelPage from '../../../../../src/views/NovelPage'
 import { getServerT } from '../../../../../src/i18n/serverI18n'
 
@@ -43,12 +44,19 @@ export async function generateMetadata({ params }) {
 async function fetchInitialNovelData(worldId) {
   const base = getServerApiBase()
   const headers = getBypassHeaders()
+  let metaRes, contentRes
   try {
-    const [metaRes, contentRes] = await Promise.all([
+    ;[metaRes, contentRes] = await Promise.all([
       fetch(`${base}/worlds/${worldId}/novel`, { headers, next: { revalidate: 60 } }),
       fetch(`${base}/worlds/${worldId}/novel/content?line_budget=100`, { headers, next: { revalidate: 60 } }),
     ])
-    if (!metaRes.ok || !contentRes.ok) return null
+  } catch {
+    return { networkError: true }
+  }
+  // Return status codes so the Page component can call notFound() / throw
+  // outside any try-catch, ensuring Next.js intercepts them correctly.
+  if (!metaRes.ok) return { httpStatus: metaRes.status }
+  try {
     const [metaJson, contentJson] = await Promise.all([metaRes.json(), contentRes.json()])
     return {
       novel: metaJson.data ?? null,
@@ -64,6 +72,11 @@ async function fetchInitialNovelData(worldId) {
 
 export default async function Page({ params }) {
   const { worldId } = params
-  const initialData = await fetchInitialNovelData(worldId)
+  const result = await fetchInitialNovelData(worldId)
+
+  if (result?.httpStatus === 404) notFound()
+  if (result?.httpStatus >= 500) throw new Error(`Novel API error: ${result.httpStatus}`)
+
+  const initialData = result?.networkError ? null : result
   return <NovelPage initialData={initialData} />
 }

--- a/app/error.jsx
+++ b/app/error.jsx
@@ -16,13 +16,6 @@ import {
 function ServerErrorIllustration() {
   return (
     <div className="relative w-64 h-56 mx-auto select-none" aria-hidden="true">
-      {/* Ghost "500" backdrop */}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <span className="text-9xl font-black text-warning/8 leading-none tracking-tighter">
-          500
-        </span>
-      </div>
-
       <svg
         viewBox="0 0 220 180"
         className="w-full h-full drop-shadow-sm"

--- a/app/error.jsx
+++ b/app/error.jsx
@@ -1,0 +1,258 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { useTranslation } from 'react-i18next'
+import '../src/i18n'
+import {
+  BookOpenIcon,
+  HomeIcon,
+  ArrowPathIcon,
+  WrenchScrewdriverIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline'
+
+/* ─── Branded illustration ────────────────────────────────────────────────── */
+function ServerErrorIllustration() {
+  return (
+    <div className="relative w-64 h-56 mx-auto select-none" aria-hidden="true">
+      {/* Ghost "500" backdrop */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <span className="text-9xl font-black text-warning/8 leading-none tracking-tighter">
+          500
+        </span>
+      </div>
+
+      <svg
+        viewBox="0 0 220 180"
+        className="w-full h-full drop-shadow-sm"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* ── Server rack units ──────────────────────────────────────────── */}
+        {/* Server unit 1 — OK */}
+        <rect
+          x="54" y="60" width="112" height="24"
+          rx="5"
+          className="fill-base-100 stroke-base-content/25"
+          strokeWidth="1.5"
+        />
+        {/* Screws */}
+        <circle cx="64" cy="72" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        <circle cx="156" cy="72" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        {/* Vents */}
+        <line x1="76" y1="65" x2="76" y2="79" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="82" y1="65" x2="82" y2="79" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="88" y1="65" x2="88" y2="79" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        {/* Status LED — green */}
+        <circle cx="140" cy="72" r="4" className="fill-success" />
+        <circle cx="140" cy="72" r="2" className="fill-success-content/40" />
+
+        {/* Server unit 2 — warning */}
+        <rect
+          x="54" y="90" width="112" height="24"
+          rx="5"
+          className="fill-base-100 stroke-base-content/25"
+          strokeWidth="1.5"
+        />
+        <circle cx="64" cy="102" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        <circle cx="156" cy="102" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        <line x1="76" y1="95" x2="76" y2="109" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="82" y1="95" x2="82" y2="109" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="88" y1="95" x2="88" y2="109" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        {/* Status LED — warning, pulsing */}
+        <circle cx="140" cy="102" r="4" className="fill-warning animate-pulse" />
+        <circle cx="140" cy="102" r="2" className="fill-warning-content/30" />
+
+        {/* Server unit 3 — error */}
+        <rect
+          x="54" y="120" width="112" height="24"
+          rx="5"
+          className="fill-base-100 stroke-base-content/25"
+          strokeWidth="1.5"
+        />
+        <circle cx="64" cy="132" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        <circle cx="156" cy="132" r="3" className="fill-base-200 stroke-base-content/20" strokeWidth="1" />
+        <line x1="76" y1="125" x2="76" y2="139" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="82" y1="125" x2="82" y2="139" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="88" y1="125" x2="88" y2="139" strokeOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        {/* Status LED — error, pulsing */}
+        <circle
+          cx="140" cy="132" r="4"
+          className="fill-error animate-pulse"
+          style={{ animationDelay: '0.3s' }}
+        />
+        <circle cx="140" cy="132" r="2" className="fill-error-content/30" />
+
+        {/* ── Lightning bolt (floating above server) ──────────────────── */}
+        <g className="animate-float" style={{ transformOrigin: '110px 36px' }}>
+          <path
+            d="M116 12 L106 36 L114 36 L104 60 L124 28 L116 28 Z"
+            className="fill-warning stroke-warning/60"
+            strokeWidth="1"
+            strokeLinejoin="round"
+          />
+        </g>
+
+        {/* ── Spark particles ──────────────────────────────────────────── */}
+        <circle
+          cx="152" cy="44" r="3"
+          className="fill-warning/50 animate-ping"
+          style={{ animationDuration: '1.6s' }}
+        />
+        <circle
+          cx="68" cy="54" r="2.5"
+          className="fill-accent/40 animate-ping"
+          style={{ animationDuration: '2.1s', animationDelay: '0.4s' }}
+        />
+        <circle
+          cx="162" cy="80" r="2"
+          className="fill-warning/35 animate-ping"
+          style={{ animationDuration: '1.9s', animationDelay: '0.7s' }}
+        />
+        <circle
+          cx="50" cy="96" r="2"
+          className="fill-error/30 animate-ping"
+          style={{ animationDuration: '2.4s', animationDelay: '1s' }}
+        />
+      </svg>
+    </div>
+  )
+}
+
+/* ─── Page ─────────────────────────────────────────────────────────────────── */
+export default function ErrorPage({ error, reset }) {
+  const { t } = useTranslation()
+  const [isRetrying, setIsRetrying] = useState(false)
+
+  useEffect(() => {
+    // Forward to any error monitoring service here
+    console.error('[Story Creator] Runtime error:', error)
+  }, [error])
+
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    await new Promise((r) => setTimeout(r, 700))
+    reset()
+    setIsRetrying(false)
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen bg-base-200">
+      {/* Minimal branded header */}
+      <header className="bg-primary text-primary-content px-5 py-3 flex items-center gap-2 shadow-md">
+        <BookOpenIcon className="w-5 h-5 flex-shrink-0" />
+        <span className="font-bold text-base tracking-wide">Story Creator</span>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 flex flex-col items-center justify-center px-4 py-12 text-center">
+        <div className="w-full max-w-md space-y-8">
+
+          {/* Illustration */}
+          <div className="animate-fade-in-up">
+            <ServerErrorIllustration />
+          </div>
+
+          {/* Heading + description */}
+          <div className="space-y-3 animate-fade-in-up animation-delay-100">
+            {/* Status badge */}
+            <div className="flex justify-center">
+              <span className="badge badge-warning badge-outline gap-1.5 py-3">
+                <WrenchScrewdriverIcon className="w-3.5 h-3.5" />
+                {t('errors.serverError.badge')}
+              </span>
+            </div>
+            <h1 className="text-2xl md:text-3xl font-bold text-base-content">
+              {t('errors.serverError.title')}
+            </h1>
+            <p className="text-base-content/60 leading-relaxed max-w-xs mx-auto text-sm md:text-base">
+              {t('errors.serverError.description')}
+            </p>
+          </div>
+
+          {/* CTAs */}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center animate-fade-in-up animation-delay-200">
+            <button
+              onClick={handleRetry}
+              disabled={isRetrying}
+              className="btn btn-primary gap-2 shadow-sm hover:shadow-md transition-shadow disabled:opacity-70"
+            >
+              {isRetrying ? (
+                <>
+                  <span className="loading loading-spinner loading-sm" />
+                  {t('errors.serverError.retrying')}
+                </>
+              ) : (
+                <>
+                  <ArrowPathIcon className="w-4 h-4" />
+                  {t('errors.serverError.retry')}
+                </>
+              )}
+            </button>
+            <Link
+              href="/"
+              className="btn btn-ghost gap-2 hover:bg-base-300 transition-colors"
+            >
+              <HomeIcon className="w-4 h-4" />
+              {t('errors.serverError.goHome')}
+            </Link>
+          </div>
+
+          {/* Reassurance card */}
+          <div className="card bg-base-100 shadow-sm animate-fade-in-up animation-delay-300">
+            <div className="card-body py-5 px-6">
+              {/* Data safety note */}
+              <div className="flex items-start gap-3 text-left">
+                <div className="mt-0.5 flex-shrink-0">
+                  <ShieldCheckIcon className="w-5 h-5 text-success" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-base-content">
+                    {t('errors.serverError.dataNote')}
+                  </p>
+                  <p className="text-xs text-base-content/60 mt-1 leading-relaxed">
+                    {t('errors.serverError.dataDescription')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="divider my-2" />
+
+              {/* What to do next */}
+              <ul className="space-y-2 text-left">
+                <li className="flex items-start gap-2.5 text-sm text-base-content/70">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-warning flex-shrink-0" />
+                  {t('errors.serverError.tip1')}
+                </li>
+                <li className="flex items-start gap-2.5 text-sm text-base-content/70">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-warning flex-shrink-0" />
+                  {t('errors.serverError.tip2')}
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          {/* Dev-only error details */}
+          {error?.message && process.env.NODE_ENV !== 'production' && (
+            <details className="text-left animate-fade-in-up">
+              <summary className="text-xs text-base-content/40 cursor-pointer hover:text-base-content/60 transition-colors select-none">
+                {t('errors.serverError.devDetails')}
+              </summary>
+              <pre className="mt-2 p-3 bg-base-100 rounded-xl text-xs text-error/80 overflow-auto max-h-36 whitespace-pre-wrap break-words">
+                {error.message}
+                {error.digest ? `\n\nDigest: ${error.digest}` : ''}
+              </pre>
+            </details>
+          )}
+
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="py-4 text-center text-xs text-base-content/35">
+        © {new Date().getFullYear()} Story Creator
+      </footer>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,6 +21,42 @@ code {
   to { transform: translateY(0); }
 }
 
+@keyframes float {
+  0%, 100% { transform: translateY(0px) rotate(0deg); }
+  50% { transform: translateY(-8px) rotate(1deg); }
+}
+
+@keyframes floatAlt {
+  0%, 100% { transform: translateY(0px) rotate(0deg); }
+  50% { transform: translateY(-6px) rotate(-1.5deg); }
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-float {
+  animation: float 3s ease-in-out infinite;
+}
+
+.animate-float-alt {
+  animation: floatAlt 3.5s ease-in-out infinite;
+}
+
+.animate-float-delay {
+  animation: float 2.8s ease-in-out infinite;
+  animation-delay: 0.6s;
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.5s ease-out both;
+}
+
+.animation-delay-100 { animation-delay: 0.1s; }
+.animation-delay-200 { animation-delay: 0.2s; }
+.animation-delay-300 { animation-delay: 0.3s; }
+
 input, textarea, select {
   font-size: 16px !important;
 }

--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -1,13 +1,234 @@
-import Link from 'next/link'
+'use client'
 
-export default function NotFound() {
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useTranslation } from 'react-i18next'
+import '../src/i18n'
+import {
+  BookOpenIcon,
+  HomeIcon,
+  ArrowLeftIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline'
+
+/* ─── Branded illustration ────────────────────────────────────────────────── */
+function NotFoundIllustration() {
   return (
-    <div className="flex flex-col justify-center items-center bg-base-200 min-h-screen text-center">
-      <h1 className="mb-2 font-bold text-5xl">404</h1>
-      <p className="mb-6 text-base-content/70">Trang không tồn tại.</p>
-      <Link href="/" className="btn btn-primary">
-        Về trang chủ
-      </Link>
+    <div className="relative w-64 h-56 mx-auto select-none" aria-hidden="true">
+      {/* Ghost "404" backdrop */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <span className="text-9xl font-black text-primary/8 leading-none tracking-tighter">
+          404
+        </span>
+      </div>
+
+      <svg
+        viewBox="0 0 220 180"
+        className="w-full h-full drop-shadow-sm"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* ── Open book base ─────────────────────────────────────────────── */}
+        {/* Spine */}
+        <rect
+          x="104" y="54" width="12" height="88"
+          rx="3"
+          className="fill-primary/25 stroke-primary/60"
+          strokeWidth="1.5"
+        />
+
+        {/* Left cover */}
+        <rect
+          x="34" y="52" width="72" height="92"
+          rx="5"
+          className="fill-base-100 stroke-primary/50"
+          strokeWidth="1.5"
+        />
+        {/* Left cover shadow strip */}
+        <rect
+          x="34" y="52" width="10" height="92"
+          rx="3"
+          className="fill-primary/10"
+        />
+        {/* Left page lines */}
+        <line x1="52" y1="78" x2="92" y2="78" strokeOpacity="0.12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <line x1="52" y1="90" x2="92" y2="90" strokeOpacity="0.12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <line x1="52" y1="102" x2="85" y2="102" strokeOpacity="0.12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <line x1="52" y1="114" x2="90" y2="114" strokeOpacity="0.12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <line x1="52" y1="126" x2="78" y2="126" strokeOpacity="0.12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+
+        {/* Right cover */}
+        <rect
+          x="114" y="52" width="72" height="92"
+          rx="5"
+          className="fill-base-100 stroke-primary/50"
+          strokeWidth="1.5"
+        />
+        {/* Right cover shadow strip */}
+        <rect
+          x="176" y="52" width="10" height="92"
+          rx="3"
+          className="fill-primary/10"
+        />
+        {/* Right page — empty with large "?" */}
+        <text
+          x="150" y="110"
+          textAnchor="middle"
+          className="fill-primary/20"
+          fontSize="52"
+          fontWeight="900"
+          fontFamily="system-ui, sans-serif"
+        >
+          ?
+        </text>
+
+        {/* ── Flying page 1 (top-right) ──────────────────────────────────── */}
+        <g className="animate-float" style={{ transformOrigin: '176px 24px' }}>
+          <rect
+            x="158" y="8" width="34" height="44"
+            rx="4"
+            transform="rotate(-18 175 30)"
+            className="fill-base-100 stroke-secondary/80"
+            strokeWidth="1.5"
+          />
+          <line x1="166" y1="22" x2="186" y2="16" strokeOpacity="0.18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="164" y1="31" x2="181" y2="25" strokeOpacity="0.18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="163" y1="40" x2="175" y2="35" strokeOpacity="0.18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </g>
+
+        {/* ── Flying page 2 (top-left) ──────────────────────────────────── */}
+        <g className="animate-float-alt" style={{ transformOrigin: '30px 30px' }}>
+          <rect
+            x="10" y="16" width="30" height="40"
+            rx="4"
+            transform="rotate(14 25 36)"
+            className="fill-base-100 stroke-secondary/70"
+            strokeWidth="1.5"
+          />
+          <line x1="16" y1="30" x2="34" y2="26" strokeOpacity="0.18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="15" y1="40" x2="31" y2="36" strokeOpacity="0.18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </g>
+
+        {/* ── Magnifying glass ──────────────────────────────────────────── */}
+        <g className="animate-float-delay" style={{ transformOrigin: '182px 136px' }}>
+          <circle
+            cx="182" cy="134" r="16"
+            className="stroke-accent fill-accent/8"
+            strokeWidth="2"
+          />
+          {/* Inner glint */}
+          <circle cx="177" cy="128" r="3" className="fill-accent/20" />
+          {/* Handle */}
+          <line
+            x1="194" y1="146" x2="205" y2="157"
+            className="stroke-accent"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </g>
+
+        {/* ── Small decorative dots ────────────────────────────────────── */}
+        <circle cx="22" cy="110" r="3" className="fill-primary/15 animate-pulse" />
+        <circle cx="198" cy="74" r="2" className="fill-secondary/25 animate-pulse" style={{ animationDelay: '0.4s' }} />
+        <circle cx="12" cy="70" r="2" className="fill-accent/20 animate-pulse" style={{ animationDelay: '0.8s' }} />
+      </svg>
+    </div>
+  )
+}
+
+/* ─── Page ─────────────────────────────────────────────────────────────────── */
+export default function NotFound() {
+  const { t } = useTranslation()
+  const router = useRouter()
+
+  return (
+    <div className="flex flex-col min-h-screen bg-base-200">
+      {/* Minimal branded header */}
+      <header className="bg-primary text-primary-content px-5 py-3 flex items-center gap-2 shadow-md">
+        <BookOpenIcon className="w-5 h-5 flex-shrink-0" />
+        <span className="font-bold text-base tracking-wide">Story Creator</span>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 flex flex-col items-center justify-center px-4 py-12 text-center">
+        <div className="w-full max-w-md space-y-8">
+
+          {/* Illustration */}
+          <div className="animate-fade-in-up">
+            <NotFoundIllustration />
+          </div>
+
+          {/* Heading + description */}
+          <div className="space-y-3 animate-fade-in-up animation-delay-100">
+            <h1 className="text-2xl md:text-3xl font-bold text-base-content">
+              {t('errors.notFound.title')}
+            </h1>
+            <p className="text-base-content/60 leading-relaxed max-w-xs mx-auto text-sm md:text-base">
+              {t('errors.notFound.description')}
+            </p>
+          </div>
+
+          {/* Primary CTAs */}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center animate-fade-in-up animation-delay-200">
+            <Link
+              href="/"
+              className="btn btn-primary gap-2 shadow-sm hover:shadow-md transition-shadow"
+            >
+              <HomeIcon className="w-4 h-4" />
+              {t('errors.notFound.goHome')}
+            </Link>
+            <button
+              onClick={() => router.back()}
+              className="btn btn-ghost gap-2 hover:bg-base-300 transition-colors"
+            >
+              <ArrowLeftIcon className="w-4 h-4" />
+              {t('errors.notFound.goBack')}
+            </button>
+          </div>
+
+          {/* Recovery suggestions card */}
+          <div className="card bg-base-100 shadow-sm text-left animate-fade-in-up animation-delay-300">
+            <div className="card-body py-5 px-6">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-base-content/50 mb-3">
+                {t('errors.notFound.suggestionsTitle')}
+              </h2>
+              <ul className="space-y-2.5">
+                {/* Suggestion 1 */}
+                <li className="flex items-start gap-2.5 text-sm text-base-content/70">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+                  {t('errors.notFound.suggestion1')}
+                </li>
+                {/* Suggestion 2 — link to stories */}
+                <li className="flex items-start gap-2.5 text-sm">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+                  <Link
+                    href="/stories"
+                    className="link link-primary hover:link-hover transition-opacity"
+                  >
+                    {t('errors.notFound.suggestion2')}
+                  </Link>
+                </li>
+                {/* Suggestion 3 — link to worlds */}
+                <li className="flex items-start gap-2.5 text-sm">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+                  <Link
+                    href="/worlds"
+                    className="link link-primary hover:link-hover transition-opacity"
+                  >
+                    {t('errors.notFound.suggestion3')}
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="py-4 text-center text-xs text-base-content/35">
+        © {new Date().getFullYear()} Story Creator
+      </footer>
     </div>
   )
 }

--- a/e2e/createWorldModal.spec.cjs
+++ b/e2e/createWorldModal.spec.cjs
@@ -12,7 +12,7 @@ async function openCreateModal(page) {
   // Wait for auth to settle and the enabled create button to appear.
   // testuser is non-admin, so the button is clickable (no btn-disabled class).
   const createBtn = page.locator('button.btn-primary:not(.btn-disabled):not([type="submit"])', {
-    hasText: /tạo thế giới mới/i,
+    hasText: /create new world/i,
   })
   await expect(createBtn).toBeVisible({ timeout: 15000 })
   await createBtn.click()
@@ -25,8 +25,8 @@ const dialogSel = 'dialog.modal[open]'
 const nameInput = (page) => page.locator(`${dialogSel} input[name="name"]`)
 const descTextarea = (page) => page.locator(`${dialogSel} textarea[name="description"]`)
 const worldTypeSelect = (page) => page.locator(`${dialogSel} select[name="world_type"]`)
-const createBtn = (page) => page.locator(`${dialogSel} button`).filter({ hasText: /phân tích/i })
-const cancelBtn = (page) => page.locator(`${dialogSel} button`).filter({ hasText: /hủy/i })
+const createBtn = (page) => page.locator(`${dialogSel} button`).filter({ hasText: /create new world/i })
+const cancelBtn = (page) => page.locator(`${dialogSel} button`).filter({ hasText: /cancel/i })
 
 // ── Suite ──────────────────────────────────────────────────────────────────
 
@@ -41,7 +41,7 @@ test.describe('Create World Modal', () => {
     await openCreateModal(page)
     await expect(page.locator(dialogSel)).toBeVisible()
     // Modal heading is inside the open dialog
-    await expect(page.locator(`${dialogSel} h3`)).toContainText(/tạo thế giới mới/i)
+    await expect(page.locator(`${dialogSel} h3`)).toContainText(/create new world/i)
   })
 
   test('cancel button closes the modal', async ({ page }) => {

--- a/e2e/createWorldModal.spec.cjs
+++ b/e2e/createWorldModal.spec.cjs
@@ -11,7 +11,7 @@ async function openCreateModal(page) {
   await page.goto('/worlds')
   // Wait for auth to settle and the enabled create button to appear.
   // testuser is non-admin, so the button is clickable (no btn-disabled class).
-  const createBtn = page.locator('button.btn-primary:not(.btn-disabled)', {
+  const createBtn = page.locator('button.btn-primary:not(.btn-disabled):not([type="submit"])', {
     hasText: /tạo thế giới mới/i,
   })
   await expect(createBtn).toBeVisible({ timeout: 15000 })

--- a/e2e/global-setup.cjs
+++ b/e2e/global-setup.cjs
@@ -63,7 +63,7 @@ module.exports = async function globalSetup(config) {
         const usersRes = await adminCtx.get('/api/admin/users?search=testuser')
         if (usersRes.ok()) {
           const usersData = await usersRes.json()
-          const testUser = (usersData.data || usersData.users || []).find(
+          const testUser = (usersData.data?.users || usersData.users || []).find(
             (u) => u.username === 'testuser'
           )
           if (testUser) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -131,7 +131,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -141,7 +141,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -172,7 +172,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -189,7 +189,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -206,7 +206,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -216,7 +216,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -230,7 +230,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -258,7 +258,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -268,7 +268,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -278,7 +278,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -288,7 +288,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -302,7 +302,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -359,7 +359,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -374,7 +374,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -393,7 +393,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1091,7 +1091,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1318,7 +1318,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -1948,6 +1948,27 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2547,6 +2568,14 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2736,6 +2765,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/unist": {
@@ -3129,7 +3168,7 @@
       "version": "2.10.22",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
       "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3176,7 +3215,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3504,7 +3543,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/crelt": {
@@ -3574,6 +3613,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/culori": {
       "version": "3.3.0",
@@ -3825,6 +3871,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -3855,7 +3909,7 @@
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3976,7 +4030,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4174,7 +4228,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4363,6 +4417,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4738,7 +4802,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4751,7 +4815,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -4856,14 +4920,41 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5746,7 +5837,7 @@
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -6187,7 +6278,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -6206,7 +6297,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -6383,6 +6474,36 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -6718,6 +6839,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",
@@ -7102,7 +7231,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7749,7 +7878,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8215,7 +8344,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -131,7 +131,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -141,7 +141,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -172,7 +172,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -189,7 +189,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -206,7 +206,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -216,7 +216,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -230,7 +230,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -258,7 +258,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -268,7 +268,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -278,7 +278,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -288,7 +288,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -302,7 +302,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -359,7 +359,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -374,7 +374,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -393,7 +393,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1091,7 +1091,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1318,7 +1318,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -1948,27 +1948,6 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2568,14 +2547,6 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2765,16 +2736,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/unist": {
@@ -3168,7 +3129,7 @@
       "version": "2.10.22",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
       "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3215,7 +3176,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3543,7 +3504,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/crelt": {
@@ -3613,13 +3574,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/culori": {
       "version": "3.3.0",
@@ -3871,14 +3825,6 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -3909,7 +3855,7 @@
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4030,7 +3976,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4228,7 +4174,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4417,16 +4363,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4802,7 +4738,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4815,7 +4751,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -4920,41 +4856,14 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lowlight": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
-      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.0.0",
-        "highlight.js": "~11.11.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -5837,7 +5746,7 @@
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -6278,7 +6187,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -6297,7 +6206,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -6474,36 +6383,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -6839,14 +6718,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",
@@ -7231,7 +7102,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7878,7 +7749,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8344,7 +8215,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -11,7 +11,7 @@ function Toast({ message, type = 'info' }) {
   }
 
   return (
-    <div className="toast toast-end top-16 z-50">
+    <div className="toast toast-end top-16 z-[9999]">
       <div className={`alert ${typeClasses[type]} shadow-lg max-w-[calc(100vw-2rem)] break-words`}>
         <span>{message}</span>
       </div>

--- a/src/containers/StoryDetailContainer.jsx
+++ b/src/containers/StoryDetailContainer.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import { notFound } from 'next/navigation'
 import { useParams, useSearchParams, useNavigate } from '../utils/router-compat'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +26,8 @@ function StoryDetailContainer({ showToast }) {
   const [linkedCharacters, setLinkedCharacters] = useState([])
   const [linkedLocations, setLinkedLocations] = useState([])
   const [loading, setLoading] = useState(true)
+  const [isNotFound, setIsNotFound] = useState(false)
+  const [fatalError, setFatalError] = useState(null)
   const [gptAnalyzing, setGptAnalyzing] = useState(false)
   const [analyzedEntities, setAnalyzedEntities] = useState(null)
   const [showAnalyzedModal, setShowAnalyzedModal] = useState(false)
@@ -70,7 +73,10 @@ function StoryDetailContainer({ showToast }) {
         setLinkedLocations([])
       }
     } catch (error) {
-      showToast(t('pages.storyDetail.loadError'), 'error')
+      const status = error.response?.status
+      if (status === 404) setIsNotFound(true)
+      else if (status >= 500) setFatalError(error)
+      else showToast(t('pages.storyDetail.loadError'), 'error')
     } finally {
       setLoading(false)
     }
@@ -231,8 +237,10 @@ function StoryDetailContainer({ showToast }) {
     }
   }
 
+  if (isNotFound) notFound()
+  if (fatalError) throw fatalError
   if (loading) return <LoadingSpinner />
-  if (!story) return <div>{t('pages.storyDetail.notFound')}</div>
+  if (!story) return null
 
   const formattedWorldTime = formatWorldTime(story)
 

--- a/src/containers/StoryReaderContainer.jsx
+++ b/src/containers/StoryReaderContainer.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import { notFound } from 'next/navigation'
 import { useParams } from '../utils/router-compat'
 import { useTranslation } from 'react-i18next'
 import { storiesAPI } from '../services/api'
@@ -12,6 +13,8 @@ function StoryReaderContainer({ showToast }) {
   const [story, setStory] = useState(null)
   const [neighbors, setNeighbors] = useState({ prev: null, next: null })
   const [isLoading, setIsLoading] = useState(true)
+  const [isNotFound, setIsNotFound] = useState(false)
+  const [fatalError, setFatalError] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -25,10 +28,12 @@ function StoryReaderContainer({ showToast }) {
         if (cancelled) return
         setStory(storyRes.data)
         setNeighbors(neighborsRes.data)
-      } catch {
-        if (!cancelled && showToast) {
-          showToast(t('pages.storyReader.loadError'), 'error')
-        }
+      } catch (error) {
+        if (cancelled) return
+        const status = error.response?.status
+        if (status === 404) setIsNotFound(true)
+        else if (status >= 500) setFatalError(error)
+        else if (showToast) showToast(t('pages.storyReader.loadError'), 'error')
       } finally {
         if (!cancelled) setIsLoading(false)
       }
@@ -36,6 +41,9 @@ function StoryReaderContainer({ showToast }) {
     load()
     return () => { cancelled = true }
   }, [storyId, showToast, t])
+
+  if (isNotFound) notFound()
+  if (fatalError) throw fatalError
 
   return (
     <StoryReaderView

--- a/src/containers/WorldDetailContainer.jsx
+++ b/src/containers/WorldDetailContainer.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react'
+import { notFound } from 'next/navigation'
 import { useParams } from '../utils/router-compat'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
@@ -27,6 +28,8 @@ function WorldDetailContainer({ showToast }) {
   const [locations, setLocations] = useState([])
   const [activeTab, setActiveTab] = useState('stories')
   const [loading, setLoading] = useState(true)
+  const [isNotFound, setIsNotFound] = useState(false)
+  const [fatalError, setFatalError] = useState(null)
   const [editing, setEditing] = useState(false)
   const [editForm, setEditForm] = useState({ name: '', description: '', visibility: '' })
   const [autoLinking, setAutoLinking] = useState(false)
@@ -67,7 +70,10 @@ function WorldDetailContainer({ showToast }) {
       setCollaborators(collabRes.data || [])
       setEditForm({ name: worldRes.data.name, description: worldRes.data.description, visibility: worldRes.data.visibility || 'draft' })
     } catch (error) {
-      showToast(t('pages.worldDetail.loadError'), 'error')
+      const status = error.response?.status
+      if (status === 404) setIsNotFound(true)
+      else if (status >= 500) setFatalError(error)
+      else showToast(t('pages.worldDetail.loadError'), 'error')
     } finally {
       setLoading(false)
     }
@@ -315,8 +321,10 @@ function WorldDetailContainer({ showToast }) {
     }
   }
 
+  if (isNotFound) notFound()
+  if (fatalError) throw fatalError
   if (loading) return <LoadingSpinner />
-  if (!world) return <div>{t('pages.worldDetail.notFound')}</div>
+  if (!world) return null
 
   const canEdit = !!(user && world && user.user_id === world.owner_id)
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -413,5 +413,30 @@
       "dragToReorder": "Drag to reorder",
       "viewFullInNovel": "Read full content in Novel →"
     }
+  },
+  "errors": {
+    "notFound": {
+      "title": "Page Not Found",
+      "description": "The page you're looking for may have been moved, deleted, or never existed in this fictional world.",
+      "goHome": "Go Home",
+      "goBack": "Go Back",
+      "suggestionsTitle": "You might try",
+      "suggestion1": "Double-check the URL for typos",
+      "suggestion2": "Browse the story collection",
+      "suggestion3": "Explore available worlds"
+    },
+    "serverError": {
+      "badge": "System error",
+      "title": "Something Went Wrong",
+      "description": "We're experiencing a technical hiccup. Don't worry — your stories are safe. Please try again in a moment.",
+      "retry": "Try Again",
+      "retrying": "Retrying…",
+      "goHome": "Go Home",
+      "dataNote": "Your data is safe",
+      "dataDescription": "All your stories and worlds are securely saved. This error is temporary.",
+      "tip1": "Wait a few seconds, then click Try Again",
+      "tip2": "If the problem persists, try refreshing the page",
+      "devDetails": "Error details (development mode)"
+    }
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -413,5 +413,30 @@
       "dragToReorder": "Kéo để sắp xếp lại",
       "viewFullInNovel": "Xem đầy đủ trong Novel →"
     }
+  },
+  "errors": {
+    "notFound": {
+      "title": "Không Tìm Thấy Trang",
+      "description": "Trang bạn đang tìm kiếm có thể đã được chuyển đi, xóa, hoặc chưa từng tồn tại trong thế giới hư cấu này.",
+      "goHome": "Về Trang Chủ",
+      "goBack": "Quay Lại",
+      "suggestionsTitle": "Bạn có thể thử",
+      "suggestion1": "Kiểm tra lại đường dẫn URL",
+      "suggestion2": "Duyệt qua kho câu chuyện",
+      "suggestion3": "Khám phá các thế giới hư cấu"
+    },
+    "serverError": {
+      "badge": "Lỗi hệ thống",
+      "title": "Đã Xảy Ra Lỗi",
+      "description": "Chúng tôi đang gặp sự cố kỹ thuật. Đừng lo lắng — câu chuyện của bạn vẫn an toàn. Hãy thử lại sau vài giây.",
+      "retry": "Thử Lại",
+      "retrying": "Đang thử lại…",
+      "goHome": "Về Trang Chủ",
+      "dataNote": "Dữ liệu của bạn an toàn",
+      "dataDescription": "Tất cả câu chuyện và thế giới của bạn đã được lưu an toàn. Lỗi này chỉ là tạm thời.",
+      "tip1": "Chờ vài giây rồi nhấn Thử Lại",
+      "tip2": "Nếu vẫn còn lỗi, hãy thử tải lại trang",
+      "devDetails": "Chi tiết lỗi (chế độ phát triển)"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **404 page** (`app/not-found.jsx`): Complete redesign with a floating open-book SVG illustration, animated flying pages and magnifying glass, clear heading/description, primary "Go Home" + secondary "Go Back" CTAs, and a recovery suggestions card linking to /stories and /worlds
- **500 page** (`app/error.jsx`): New Next.js error boundary page with an animated server-rack SVG (traffic-light status LEDs + floating lightning bolt), retry-with-loading-state CTA, data-safety reassurance card, and dev-only error detail disclosure
- **Animations** (`app/globals.css`): Added `@keyframes float`, `floatAlt`, `fadeInUp` and corresponding utility classes (`.animate-float`, `.animate-fade-in-up`, etc.)
- **i18n** (`en.json` / `vi.json`): Added `errors.notFound` and `errors.serverError` translation namespaces in both English and Vietnamese

## Design system compliance

| Requirement | Implementation |
|---|---|
| DaisyUI semantic tokens only | All colors via `text-primary`, `bg-base-100`, `stroke-warning`, etc. — zero hardcoded hex |
| Theme switching (light / dark / custom) | `data-theme` on `<html>` propagates automatically; CSS vars override in custom mode |
| Responsive | Mobile-first; CTAs stack vertically on small screens, row on `sm:` |
| Accessible | Decorative SVGs marked `aria-hidden="true"`; buttons have visible focus states |
| Branded storytelling metaphors | 404 = lost book/magnifying glass; 500 = server rack with lightning — on-brand for a fiction platform |
| i18n | All strings via `useTranslation` with `errors.*` namespace keys |

## Test plan

- [ ] Visit `/nonexistent-path` — verify 404 page renders with illustration and both CTAs work
- [ ] Trigger a runtime error (e.g., throw in a page component) — verify 500 page renders, "Try Again" shows spinner then calls `reset()`, "Go Home" navigates to `/`
- [ ] Switch themes (Light → Dark → storyCreator custom) — verify illustration, text, and cards all adapt without hardcoded color bleed
- [ ] Test on mobile viewport (375px) — CTAs should stack, illustration should scale
- [ ] Verify Vietnamese strings display correctly when language is set to `vi`

https://claude.ai/code/session_019VWoW8TjWKAEc54KmyBM7Q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VWoW8TjWKAEc54KmyBM7Q)_