### PR TITLE
fix: resolve mobile modal, permission buttons, and world creation UX

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -117,6 +117,7 @@ function Navbar() {
   )
 
   return (
+    <>
     <div
       className={[
         'bg-primary shadow-lg text-primary-content navbar',
@@ -234,19 +235,22 @@ function Navbar() {
         )}
       </div>
 
-      {/* Logout Confirmation Modal */}
-      <Modal open={showLogoutModal} onClose={cancelLogout} title={t('nav.logoutConfirmTitle')} className="max-w-sm">
-        <p className="text-sm opacity-80 mb-6">{t('nav.logoutConfirmMsg')}</p>
-        <div className="flex justify-end gap-2">
-          <button className="btn btn-ghost btn-sm" onClick={cancelLogout}>
-            {t('common.cancel')}
-          </button>
-          <button className="btn btn-error btn-sm" onClick={confirmLogout}>
-            {t('actions.logout')}
-          </button>
-        </div>
-      </Modal>
     </div>
+
+    {/* Logout Confirmation Modal — rendered outside the sticky navbar to avoid
+        will-change:transform creating a new stacking context that breaks fixed positioning */}
+    <Modal open={showLogoutModal} onClose={cancelLogout} title={t('nav.logoutConfirmTitle')} className="max-w-sm">
+      <p className="text-sm opacity-80 mb-6">{t('nav.logoutConfirmMsg')}</p>
+      <div className="flex justify-end gap-2">
+        <button className="btn btn-ghost btn-sm" onClick={cancelLogout}>
+          {t('common.cancel')}
+        </button>
+        <button className="btn btn-error btn-sm" onClick={confirmLogout}>
+          {t('actions.logout')}
+        </button>
+      </div>
+    </Modal>
+    </>
   )
 }
 

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -11,7 +11,7 @@ function Toast({ message, type = 'info' }) {
   }
 
   return (
-    <div className="toast toast-end toast-top">
+    <div className="toast toast-end top-16 z-50">
       <div className={`alert ${typeClasses[type]} shadow-lg max-w-[calc(100vw-2rem)] break-words`}>
         <span>{message}</span>
       </div>

--- a/src/components/stories/StoriesView.jsx
+++ b/src/components/stories/StoriesView.jsx
@@ -70,24 +70,10 @@ function StoriesView({
         <h1 className="font-bold text-3xl">
           <BookOpenIcon className="inline w-8 h-8" /> Câu chuyện
         </h1>
-        {worlds.length > 0 ? (
-          authLoading ? (
-            <button className="btn btn-primary" disabled>
-              <span className="loading loading-spinner loading-xs" />
-            </button>
-          ) : user ? (
-            <button onClick={handleCreateStoryClick} className="btn btn-primary">
-              + Tạo câu chuyện mới
-            </button>
-          ) : (
-            <div className="tooltip tooltip-left" data-tip="Vui lòng đăng nhập để tạo câu chuyện">
-              <button className="btn btn-disabled" disabled>+ Tạo câu chuyện mới</button>
-            </div>
-          )
-        ) : (
-          <div className="tooltip tooltip-left" data-tip="Tạo thế giới trước để bắt đầu">
-            <button className="btn btn-disabled" disabled>+ Tạo câu chuyện mới</button>
-          </div>
+        {worlds.length > 0 && !authLoading && user && (
+          <button onClick={handleCreateStoryClick} className="btn btn-primary">
+            + Tạo câu chuyện mới
+          </button>
         )}
       </div>
 

--- a/src/components/stories/StoriesView.jsx
+++ b/src/components/stories/StoriesView.jsx
@@ -11,7 +11,6 @@ import {
   UserIcon,
 } from '@heroicons/react/24/outline'
 import { marked } from 'marked'
-import Modal from '../Modal'
 
 function toPlainText(content) {
   if (!content) return ''
@@ -53,27 +52,44 @@ function StoriesView({
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [showWorldPicker, setShowWorldPicker] = useState(false)
+  const [selectedWorldId, setSelectedWorldId] = useState('')
+
+  const effectiveWorldId = selectedWorldId || (worlds[0]?.world_id ?? '')
 
   const handleCreateStoryClick = () => {
-    if (worlds.length === 1) {
-      navigate(`/stories/new?worldId=${worlds[0].world_id}`)
-    } else {
-      setShowWorldPicker(true)
-    }
+    if (effectiveWorldId) navigate(`/stories/new?worldId=${effectiveWorldId}`)
   }
 
   return (
     <div>
       {/* ── Page header ─────────────────────────────────────────────── */}
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="font-bold text-3xl">
+      <div className="mb-6">
+        <h1 className="font-bold text-3xl mb-4">
           <BookOpenIcon className="inline w-8 h-8" /> Câu chuyện
         </h1>
-        {worlds.length > 0 && !authLoading && user && (
-          <button onClick={handleCreateStoryClick} className="btn btn-primary">
-            + Tạo câu chuyện mới
-          </button>
+
+        {/* World selector + CTA — only shown for authenticated users with worlds */}
+        {!authLoading && user && worlds.length > 0 && (
+          <div className="flex flex-col sm:flex-row gap-3">
+            <select
+              className="select select-bordered flex-1 max-w-xs"
+              value={effectiveWorldId}
+              onChange={e => setSelectedWorldId(e.target.value)}
+            >
+              {worlds.map(world => (
+                <option key={world.world_id} value={world.world_id}>
+                  {world.name}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={handleCreateStoryClick}
+              disabled={!effectiveWorldId}
+              className="btn btn-primary"
+            >
+              + Tạo câu chuyện mới
+            </button>
+          </div>
         )}
       </div>
 
@@ -186,40 +202,6 @@ function StoriesView({
         </div>
       )}
 
-      {/* ── World picker modal ──────────────────────────────────────── */}
-      <Modal
-        open={showWorldPicker}
-        onClose={() => setShowWorldPicker(false)}
-        title="Chọn thế giới"
-        className="max-w-sm"
-      >
-        <p className="mb-4 text-sm text-base-content/70">
-          Câu chuyện sẽ được tạo trong thế giới nào?
-        </p>
-        <div className="flex flex-col gap-2">
-          {worlds.map(world => {
-            const c = paletteFor(world.name)
-            return (
-              <Link
-                key={world.world_id}
-                to={`/stories/new?worldId=${world.world_id}`}
-                className={`btn btn-outline justify-start border-l-4 ${c.border}`}
-                onClick={() => setShowWorldPicker(false)}
-              >
-                <span className={`w-2 h-2 rounded-full ${c.dot}`} />
-                <GlobeAltIcon className="w-4 h-4 shrink-0" />
-                <span className="truncate">{world.name}</span>
-                <span className="ml-auto text-xs opacity-50">{world.world_type}</span>
-              </Link>
-            )
-          })}
-        </div>
-        <div className="flex justify-end mt-6">
-          <button type="button" onClick={() => setShowWorldPicker(false)} className="btn btn-ghost btn-sm">
-            Hủy
-          </button>
-        </div>
-      </Modal>
     </div>
   )
 }

--- a/src/views/WorldsPage.jsx
+++ b/src/views/WorldsPage.jsx
@@ -7,13 +7,11 @@ import { worldsAPI, gptAPI } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
 import LoadingSpinner from '../components/LoadingSpinner'
-import GptButton, { OpenAILogo } from '../components/GptButton'
+import GptButton from '../components/GptButton'
 import {
   GlobeAltIcon,
   LockClosedIcon,
   UserIcon,
-  MapPinIcon,
-  ArrowPathIcon,
   BookOpenIcon,
 } from '@heroicons/react/24/outline'
 import Tag from '../components/Tag'
@@ -21,7 +19,7 @@ import Tag from '../components/Tag'
 function WorldsPage({ initialWorlds }) {
   const { showToast } = useToast()
   const { t } = useTranslation()
-  const { isAuthenticated, user, loading: authLoading } = useAuth()
+  const { isAuthenticated, user, loading: authLoading, canUseGpt } = useAuth()
 
   // Skip the initial client-side fetch when SSR pre-fetched public worlds.
   // Re-fetch still fires when the user authenticates (private worlds become visible).
@@ -36,7 +34,6 @@ function WorldsPage({ initialWorlds }) {
     world_type: 'fantasy',
   })
   const [gptAnalyzing, setGptAnalyzing] = useState(false)
-  const [gptEntities, setGptEntities] = useState(null)
   const dialogRef = useRef(null)
 
   useEffect(() => {
@@ -131,56 +128,6 @@ function WorldsPage({ initialWorlds }) {
     }
   }
 
-  const analyzeWithGPT = async () => {
-    if (!isAuthenticated) {
-      showToast(t('pages.worlds.toast.loginRequired'), 'warning')
-      return
-    }
-    if (!formData.description) {
-      showToast(t('pages.worlds.toast.descRequired'), 'warning')
-      return
-    }
-    if (!formData.name) {
-      showToast(t('pages.worlds.toast.nameRequiredGpt'), 'warning')
-      return
-    }
-
-    try {
-      setGptAnalyzing(true)
-      const response = await gptAPI.analyze({
-        world_description: formData.description,
-        world_type: formData.world_type
-      })
-
-      const taskId = response.data.task_id
-
-      // Poll for results
-      const checkResults = async () => {
-        try {
-          const result = await gptAPI.getResults(taskId)
-          if (result.data.status === 'completed') {
-            setGptEntities(result.data.result)
-            showToast(t('pages.worlds.toast.gptAnalysisDone'), 'success')
-            setGptAnalyzing(false)
-          } else if (result.data.status === 'error') {
-            showToast(result.data.result, 'error')
-            setGptAnalyzing(false)
-          } else {
-            setTimeout(checkResults, 500)
-          }
-        } catch (err) {
-          showToast(t('pages.worlds.toast.gptAnalysisError'), 'error')
-          setGptAnalyzing(false)
-        }
-      }
-
-      checkResults()
-    } catch (error) {
-      showToast(t('pages.worlds.toast.gptAnalysisError'), 'error')
-      setGptAnalyzing(false)
-    }
-  }
-
   const handleSubmit = async (e) => {
     e.preventDefault()
 
@@ -196,55 +143,19 @@ function WorldsPage({ initialWorlds }) {
 
     try {
       setGptAnalyzing(true)
-
-      // Auto-analyze with GPT
-      const gptResponse = await gptAPI.analyze({
-        world_description: formData.description,
-        world_type: formData.world_type
-      })
-
-      const taskId = gptResponse.data.task_id
-
-      // Poll for GPT results
-      const checkResults = async () => {
-        try {
-          const result = await gptAPI.getResults(taskId)
-          if (result.data.status === 'completed') {
-            const entities = result.data.result
-
-            // Create world with GPT entities
-            const payload = {
-              ...formData,
-              gpt_entities: entities
-            }
-
-            await worldsAPI.create(payload)
-            showToast(t('pages.worlds.toast.createSuccess', { chars: entities.characters?.length || 0, locs: entities.locations?.length || 0 }), 'success')
-            setShowCreateModal(false)
-            setGptAnalyzing(false)
-            loadWorlds()
-          } else if (result.data.status === 'error') {
-            showToast(t('pages.worlds.toast.createError'), 'error')
-            setGptAnalyzing(false)
-          } else {
-            setTimeout(checkResults, 500)
-          }
-        } catch (err) {
-          showToast(t('pages.worlds.toast.createError'), 'error')
-          setGptAnalyzing(false)
-        }
-      }
-
-      checkResults()
+      await worldsAPI.create(formData)
+      showToast(t('pages.worlds.toast.createSuccess', { chars: 0, locs: 0 }), 'success')
+      setShowCreateModal(false)
+      loadWorlds()
     } catch (error) {
       showToast(t('pages.worlds.toast.createError'), 'error')
+    } finally {
       setGptAnalyzing(false)
     }
   }
 
   const resetForm = () => {
     setFormData({ name: '', description: '', world_type: 'fantasy' })
-    setGptEntities(null)
   }
 
   const deleteWorld = async (worldId) => {
@@ -383,16 +294,18 @@ function WorldsPage({ initialWorlds }) {
                   <label className="label py-0">
                     <span className="label-text">{t('pages.worlds.description')}</span>
                   </label>
-                  <GptButton
-                    onClick={generateDescriptionWithGPT}
-                    loading={gptAnalyzing}
-                    loadingText={t('pages.worlds.gptGenerating')}
-                    disabled={!formData.name}
-                    variant="secondary"
-                    size="xs"
-                  >
-                    Tạo mô tả
-                  </GptButton>
+                  {canUseGpt && (
+                    <GptButton
+                      onClick={generateDescriptionWithGPT}
+                      loading={gptAnalyzing}
+                      loadingText={t('pages.worlds.gptGenerating')}
+                      disabled={!formData.name}
+                      variant="secondary"
+                      size="xs"
+                    >
+                      Tạo mô tả
+                    </GptButton>
+                  )}
                 </div>
                 <textarea
                   name="description"
@@ -404,70 +317,19 @@ function WorldsPage({ initialWorlds }) {
                 />
                 <label className="label">
                   <span className="label-text-alt">{t('pages.worlds.charCount', { count: formData.description.length })}</span>
-                  <span className="label-text-alt text-base-content/40">{t('pages.worlds.gptHint')}</span>
                 </label>
               </div>
 
-              {/* GPT Entities Preview */}
-              {gptEntities && (
-                <div className="bg-base-200/50 mb-4 p-4 border border-base-300 rounded-xl">
-                  <div className="w-full">
-                    <div className="flex justify-between items-center mb-3">
-                      <span className="flex items-center gap-2 font-semibold">
-                        <span className="flex justify-center items-center bg-gradient-to-br from-emerald-500/20 to-teal-500/20 rounded-full w-6 h-6 text-emerald-600">
-                          <OpenAILogo className="w-3.5 h-3.5" />
-                        </span>
-                        {t('pages.worlds.analysisResult')}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => setGptEntities(null)}
-                        className="opacity-50 hover:opacity-100 btn btn-ghost btn-xs btn-circle"
-                      >
-                        ✕
-                      </button>
-                    </div>
-                    {gptEntities.characters?.length > 0 && (
-                      <div className="mb-3">
-                        <span className="opacity-70 text-sm"><UserIcon className="inline w-3.5 h-3.5" /> Nhân vật ({gptEntities.characters.length}):</span>
-                        <div className="flex flex-wrap gap-2 mt-1">
-                          {gptEntities.characters.map((char, i) => (
-                            <span key={i} className="bg-primary/10 px-2 py-1 border border-primary/30 rounded-lg font-medium text-primary text-sm">
-                              {char.name} - {char.entity_type}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {gptEntities.locations?.length > 0 && (
-                      <div>
-                        <span className="opacity-70 text-sm"><MapPinIcon className="inline w-3.5 h-3.5" /> Địa điểm ({gptEntities.locations.length}):</span>
-                        <div className="flex flex-wrap gap-2 mt-1">
-                          {gptEntities.locations.map((loc, i) => (
-                            <span key={i} className="bg-secondary/10 px-2 py-1 border border-secondary/30 rounded-lg font-medium text-secondary text-sm">
-                              {loc.name} - {loc.location_type}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {(!gptEntities.characters?.length && !gptEntities.locations?.length) && (
-                      <p className="opacity-70 text-sm">{t('pages.worlds.noEntities')}</p>
-                    )}
-                  </div>
-                </div>
-              )}
-
               <div className="modal-action">
-                <GptButton
-                  onClick={handleSubmit}
-                  loading={gptAnalyzing}
-                  loadingText={t('actions.processing')}
-                  variant="primary"
-                  size="md"
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={gptAnalyzing}
                 >
-                  {t('pages.worlds.createAndAnalyze')}
-                </GptButton>
+                  {gptAnalyzing ? (
+                    <><span className="loading loading-spinner loading-xs" />{t('actions.processing')}</>
+                  ) : t('pages.worlds.createBtn')}
+                </button>
                 <button type="button" onClick={() => dialogRef.current?.close()} className="btn" disabled={gptAnalyzing}>{t('common.cancel')}</button>
               </div>
             </form>


### PR DESCRIPTION
## Summary

- **Logout modal misaligned on mobile**: The sticky navbar had `will-change: transform` which creates a new CSS stacking context, causing `fixed`-positioned children (the Modal) to be offset instead of covering the full viewport. Fixed by rendering `<Modal>` outside the sticky `<div>`.
- **Hide unavailable buttons**: The create-story button on the Stories page is now hidden entirely (not disabled/greyed out) when there are no worlds or the user is not authenticated.
- **World creation simplified**: Removed the GPT auto-analyze step from world creation — the form now creates the world directly. The GPT "Tạo mô tả" (generate description) button is hidden when the user lacks GPT permission (`canUseGpt`).

## Test plan

- [ ] Open hamburger menu on mobile → tap logout → confirm modal appears centered at the bottom of the viewport (not clipped or offset)
- [ ] Visit /stories while logged out → no create-story button visible
- [ ] Visit /stories while logged in but with no worlds → no create-story button visible
- [ ] Visit /worlds → click "+ Tạo thế giới mới" → form submits immediately after filling name + description (no GPT analysis step)
- [ ] As a user without GPT permission, open world creation modal → "Tạo mô tả" button is not shown

https://claude.ai/code/session_01NimS6nRh46GKzUXZDhkcw9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NimS6nRh46GKzUXZDhkcw9)_