### PR TITLE
feat: floating writing modal for desktop draft continuation

### DIFF
--- a/app/Providers.jsx
+++ b/app/Providers.jsx
@@ -8,6 +8,8 @@ import { GptTaskProvider } from '../src/contexts/GptTaskContext'
 import { ToastProvider, useToast } from '../src/contexts/ToastContext'
 import Toast from '../src/components/Toast'
 import { useKeepAlive } from '../src/hooks/useKeepAlive'
+import { WritingModalProvider } from '../src/contexts/WritingModalContext'
+import WritingModal from '../src/components/writingModal/WritingModal'
 import '../src/i18n'
 
 function ToastOutlet() {
@@ -25,6 +27,16 @@ function KeepAlive() {
   return null
 }
 
+function WritingModalBridge({ children }) {
+  const { showToast } = useToast()
+  return (
+    <WritingModalProvider showToast={showToast}>
+      {children}
+      <WritingModal />
+    </WritingModalProvider>
+  )
+}
+
 export default function Providers({ children }) {
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || ''
   return (
@@ -34,9 +46,11 @@ export default function Providers({ children }) {
           <ToastProvider>
             <AuthProvider>
               <GptTaskBridge>
-                <KeepAlive />
-                {children}
-                <ToastOutlet />
+                <WritingModalBridge>
+                  <KeepAlive />
+                  {children}
+                  <ToastOutlet />
+                </WritingModalBridge>
               </GptTaskBridge>
             </AuthProvider>
           </ToastProvider>

--- a/src/components/writingModal/WritingModal.jsx
+++ b/src/components/writingModal/WritingModal.jsx
@@ -1,0 +1,195 @@
+'use client'
+
+import React, { useState, useCallback, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslation } from 'react-i18next'
+import { useWritingModal } from '../../contexts/WritingModalContext'
+import NovelEditor from '../storyEditor/NovelEditor'
+import FormattingToolbar from '../storyEditor/FormattingToolbar'
+import {
+  PencilSquareIcon,
+  MinusIcon,
+  XMarkIcon,
+  ArrowsPointingOutIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ArrowPathIcon,
+} from '@heroicons/react/24/outline'
+
+const STATUS_CONFIG = {
+  idle: { label: 'writingModal.statusIdle', cls: 'text-base-content/40' },
+  saving: { label: 'writingModal.statusSaving', cls: 'text-info', icon: ArrowPathIcon },
+  saved: { label: 'writingModal.statusSaved', cls: 'text-success', icon: CheckCircleIcon },
+  error: { label: 'writingModal.statusError', cls: 'text-error', icon: ExclamationCircleIcon },
+}
+
+function SaveStatusBadge({ status }) {
+  const { t } = useTranslation()
+  const cfg = STATUS_CONFIG[status] || STATUS_CONFIG.idle
+  const Icon = cfg.icon
+  return (
+    <span className={`flex items-center gap-1 text-xs ${cfg.cls}`}>
+      {Icon && <Icon className={`w-3 h-3 ${status === 'saving' ? 'animate-spin' : ''}`} />}
+      {t(cfg.label)}
+    </span>
+  )
+}
+
+function MinimizedButton({ onClick }) {
+  const { t } = useTranslation()
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-6 right-6 z-50 hidden md:flex items-center gap-2 btn btn-primary shadow-xl rounded-full pl-4 pr-5"
+      title={t('writingModal.openDraft')}
+    >
+      <PencilSquareIcon className="w-5 h-5" />
+      <span className="text-sm font-medium">{t('writingModal.continueDraft')}</span>
+    </button>
+  )
+}
+
+function WritingModal() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const {
+    modalState,
+    draft,
+    editorRef,
+    openModal,
+    minimizeModal,
+    closeModal,
+    handleTitleChange,
+    handleContentUpdate,
+    handleSave,
+    handlePublish,
+  } = useWritingModal()
+
+  const [activeFormats, setActiveFormats] = useState({})
+
+  const getActiveFormats = useCallback((ed) => ({
+    bold: ed.isActive('bold'),
+    italic: ed.isActive('italic'),
+    underline: ed.isActive('underline'),
+    strike: ed.isActive('strike'),
+    highlight: ed.isActive('highlight'),
+    h1: ed.isActive('heading', { level: 1 }),
+    h2: ed.isActive('heading', { level: 2 }),
+    h3: ed.isActive('heading', { level: 3 }),
+    bulletList: ed.isActive('bulletList'),
+    orderedList: ed.isActive('orderedList'),
+    alignLeft: ed.isActive({ textAlign: 'left' }),
+    alignCenter: ed.isActive({ textAlign: 'center' }),
+    alignRight: ed.isActive({ textAlign: 'right' }),
+  }), [])
+
+  const handleEditorUpdate = useCallback(({ html, editor }) => {
+    handleContentUpdate({ html })
+    setActiveFormats(getActiveFormats(editor))
+  }, [handleContentUpdate, getActiveFormats])
+
+  const handleSelectionChange = useCallback(({ editor }) => {
+    setActiveFormats(getActiveFormats(editor))
+  }, [getActiveFormats])
+
+  const handleMaximize = useCallback(() => {
+    if (draft.storyId) {
+      handleSave()
+      router.push(`/stories/${draft.storyId}/edit`)
+    }
+    minimizeModal()
+  }, [draft.storyId, handleSave, router, minimizeModal])
+
+  const canPublish = draft.saveStatus === 'saved' && !draft.isPublished && !!draft.storyId
+
+  if (modalState === 'closed') return null
+
+  if (modalState === 'minimized') {
+    return <MinimizedButton onClick={openModal} />
+  }
+
+  return (
+    // Hidden on mobile — full editor page is used on small screens
+    <div className="hidden md:flex fixed bottom-0 right-6 z-50 flex-col w-[38%] min-w-[340px] max-w-[560px] h-[60vh] min-h-[400px] bg-base-100 border border-base-300 rounded-t-xl shadow-2xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 bg-base-200 border-b border-base-300 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <PencilSquareIcon className="w-4 h-4 text-primary shrink-0" />
+          <input
+            type="text"
+            value={draft.title}
+            onChange={(e) => handleTitleChange(e.target.value)}
+            placeholder={t('writingModal.titlePlaceholder')}
+            className="input input-ghost input-xs text-sm font-medium w-full min-w-0 focus:outline-none px-0"
+          />
+        </div>
+        <div className="flex items-center gap-1 shrink-0 ml-2">
+          <SaveStatusBadge status={draft.saveStatus} />
+          <div className="w-px h-4 bg-base-300 mx-1" />
+          <button
+            onClick={minimizeModal}
+            className="btn btn-ghost btn-xs h-7 min-h-0 px-1.5"
+            title={t('writingModal.minimize')}
+          >
+            <MinusIcon className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleMaximize}
+            className="btn btn-ghost btn-xs h-7 min-h-0 px-1.5"
+            title={t('writingModal.maximize')}
+          >
+            <ArrowsPointingOutIcon className="w-4 h-4" />
+          </button>
+          <button
+            onClick={closeModal}
+            className="btn btn-ghost btn-xs h-7 min-h-0 px-1.5 text-error hover:bg-error/10"
+            title={t('writingModal.close')}
+          >
+            <XMarkIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <FormattingToolbar editorRef={editorRef} activeFormats={activeFormats} />
+
+      {/* Editor body */}
+      <div className="flex-1 overflow-y-auto relative">
+        {draft.isLoading ? (
+          <div className="flex items-center justify-center h-full">
+            <span className="loading loading-spinner loading-sm text-primary" />
+          </div>
+        ) : (
+          <NovelEditor
+            key={draft.storyId ?? 'new'}
+            initialContent={draft.content}
+            format="html"
+            editorRef={editorRef}
+            onUpdate={handleEditorUpdate}
+            onSelectionChange={handleSelectionChange}
+          />
+        )}
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex items-center justify-end gap-2 px-3 py-2 border-t border-base-300 bg-base-100 shrink-0">
+        <button
+          onClick={handleSave}
+          disabled={draft.saveStatus === 'saving'}
+          className="btn btn-sm btn-ghost"
+        >
+          {t('writingModal.save')}
+        </button>
+        <button
+          onClick={handlePublish}
+          disabled={!canPublish || draft.saveStatus === 'saving'}
+          className="btn btn-sm btn-primary"
+        >
+          {t('writingModal.publish')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default WritingModal

--- a/src/contexts/WritingModalContext.jsx
+++ b/src/contexts/WritingModalContext.jsx
@@ -1,0 +1,218 @@
+'use client'
+
+import React, { createContext, useContext, useState, useRef, useCallback, useEffect } from 'react'
+import TurndownService from 'turndown'
+import { marked } from 'marked'
+import { storiesAPI } from '../services/api'
+import { useAuth } from './AuthContext'
+
+const turndownSvc = new TurndownService({ headingStyle: 'atx', bulletListMarker: '-' })
+const toMarkdown = (html) => turndownSvc.turndown(html || '')
+
+const AUTO_SAVE_DELAY = 2_000
+
+const WritingModalContext = createContext(null)
+
+export function WritingModalProvider({ children, showToast }) {
+  const { user } = useAuth()
+
+  // Modal visibility state
+  const [modalState, setModalState] = useState('closed') // 'closed' | 'open' | 'minimized'
+
+  // Draft content state
+  const [draft, setDraft] = useState({
+    storyId: null,
+    worldId: null,
+    title: '',
+    content: '',
+    saveStatus: 'idle', // 'idle' | 'saving' | 'saved' | 'error'
+    isPublished: false,
+    isLoading: false,
+  })
+
+  // Mutable refs — avoid stale closures in doSave
+  const draftRef = useRef({ title: '', content: '' })
+  const lastSavedRef = useRef({ title: '', content: '' })
+  const storyIdRef = useRef(null)
+  const worldIdRef = useRef(null)
+  const saveTimerRef = useRef(null)
+  const editorRef = useRef(null)
+
+  // Check for active draft when user logs in
+  useEffect(() => {
+    if (!user) return
+    checkForActiveDraft()
+  }, [user])
+
+  const checkForActiveDraft = useCallback(async () => {
+    try {
+      const res = await storiesAPI.getMyDraft()
+      const story = res.data?.story ?? res.data
+      if (!story) return
+      // Show modal only if draft exists and we're not already open
+      setModalState((prev) => (prev === 'closed' ? 'minimized' : prev))
+    } catch {
+      // Not critical
+    }
+  }, [])
+
+  const loadDraft = useCallback(async () => {
+    setDraft((prev) => ({ ...prev, isLoading: true }))
+    try {
+      const res = await storiesAPI.getMyDraft()
+      const story = res.data?.story ?? res.data
+      if (!story) {
+        setDraft((prev) => ({ ...prev, isLoading: false }))
+        return
+      }
+      const rawContent = story.content || ''
+      const htmlContent = story.format === 'markdown' ? marked.parse(rawContent) : rawContent
+      const markdownBaseline = story.format === 'markdown' ? rawContent : toMarkdown(rawContent)
+
+      storyIdRef.current = story.story_id
+      worldIdRef.current = story.world_id
+      draftRef.current = { title: story.title || '', content: htmlContent }
+      lastSavedRef.current = { title: story.title || '', content: markdownBaseline }
+
+      setDraft({
+        storyId: story.story_id,
+        worldId: story.world_id,
+        title: story.title || '',
+        content: htmlContent,
+        saveStatus: 'saved',
+        isPublished: story.visibility === 'public',
+        isLoading: false,
+      })
+    } catch {
+      setDraft((prev) => ({ ...prev, isLoading: false }))
+    }
+  }, [])
+
+  const doSave = useCallback(async () => {
+    const { title, content } = draftRef.current
+    const markdownContent = toMarkdown(content)
+    const last = lastSavedRef.current
+    if (title === last.title && markdownContent === last.content) return
+
+    setDraft((prev) => ({ ...prev, saveStatus: 'saving' }))
+    try {
+      if (!storyIdRef.current) {
+        const worldId = worldIdRef.current
+        if (!worldId) {
+          setDraft((prev) => ({ ...prev, saveStatus: 'error' }))
+          return
+        }
+        const res = await storiesAPI.create({
+          world_id: worldId,
+          title: title.trim() || '(no title)',
+          content: markdownContent,
+          visibility: 'draft',
+          format: 'markdown',
+        })
+        storyIdRef.current = res.data.story_id
+        setDraft((prev) => ({ ...prev, storyId: res.data.story_id }))
+      } else {
+        await storiesAPI.patch(storyIdRef.current, {
+          title: title.trim() || '(no title)',
+          content: markdownContent,
+          format: 'markdown',
+        })
+      }
+      lastSavedRef.current = { title: title.trim() || '(no title)', content: markdownContent }
+      setDraft((prev) => ({ ...prev, saveStatus: 'saved' }))
+    } catch {
+      setDraft((prev) => ({ ...prev, saveStatus: 'error' }))
+      showToast?.('Failed to save draft', 'error')
+    }
+  }, [showToast])
+
+  const scheduleAutoSave = useCallback(() => {
+    clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(doSave, AUTO_SAVE_DELAY)
+  }, [doSave])
+
+  const handleTitleChange = useCallback((value) => {
+    draftRef.current = { ...draftRef.current, title: value }
+    setDraft((prev) => ({ ...prev, title: value, saveStatus: 'idle' }))
+    scheduleAutoSave()
+  }, [scheduleAutoSave])
+
+  const handleContentUpdate = useCallback(({ html }) => {
+    draftRef.current = { ...draftRef.current, content: html }
+    setDraft((prev) => ({ ...prev, content: html, saveStatus: 'idle' }))
+    scheduleAutoSave()
+  }, [scheduleAutoSave])
+
+  const handleSave = useCallback(() => {
+    clearTimeout(saveTimerRef.current)
+    doSave()
+  }, [doSave])
+
+  const handlePublish = useCallback(async () => {
+    if (!storyIdRef.current) await doSave()
+    if (!storyIdRef.current) return
+    try {
+      await storiesAPI.update(storyIdRef.current, { visibility: 'public' })
+      setDraft((prev) => ({ ...prev, isPublished: true, saveStatus: 'saved' }))
+      showToast?.('Story published!', 'success')
+      // After publish, close the modal — don't re-open this draft
+      closeModal()
+    } catch {
+      showToast?.('Failed to publish', 'error')
+    }
+  }, [doSave, showToast])
+
+  const openModal = useCallback(async () => {
+    // Always refetch from server on open (server is source of truth)
+    setModalState('open')
+    await loadDraft()
+  }, [loadDraft])
+
+  const minimizeModal = useCallback(() => {
+    setModalState('minimized')
+  }, [])
+
+  const closeModal = useCallback(() => {
+    clearTimeout(saveTimerRef.current)
+    setModalState('closed')
+    // Reset state
+    storyIdRef.current = null
+    worldIdRef.current = null
+    draftRef.current = { title: '', content: '' }
+    lastSavedRef.current = { title: '', content: '' }
+    setDraft({
+      storyId: null, worldId: null, title: '', content: '',
+      saveStatus: 'idle', isPublished: false, isLoading: false,
+    })
+  }, [])
+
+  // Flush pending save on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(saveTimerRef.current)
+    }
+  }, [])
+
+  return (
+    <WritingModalContext.Provider value={{
+      modalState,
+      draft,
+      editorRef,
+      openModal,
+      minimizeModal,
+      closeModal,
+      handleTitleChange,
+      handleContentUpdate,
+      handleSave,
+      handlePublish,
+    }}>
+      {children}
+    </WritingModalContext.Provider>
+  )
+}
+
+export function useWritingModal() {
+  const ctx = useContext(WritingModalContext)
+  if (!ctx) throw new Error('useWritingModal must be used inside WritingModalProvider')
+  return ctx
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -438,5 +438,19 @@
       "tip2": "If the problem persists, try refreshing the page",
       "devDetails": "Error details (development mode)"
     }
+  },
+  "writingModal": {
+    "titlePlaceholder": "Story title…",
+    "minimize": "Minimize",
+    "maximize": "Open full editor",
+    "close": "Close",
+    "openDraft": "Open draft",
+    "continueDraft": "Continue writing",
+    "save": "Save",
+    "publish": "Publish",
+    "statusIdle": "Unsaved",
+    "statusSaving": "Saving…",
+    "statusSaved": "Saved",
+    "statusError": "Error"
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -438,5 +438,19 @@
       "tip2": "Nếu vẫn còn lỗi, hãy thử tải lại trang",
       "devDetails": "Chi tiết lỗi (chế độ phát triển)"
     }
+  },
+  "writingModal": {
+    "titlePlaceholder": "Tiêu đề câu chuyện…",
+    "minimize": "Thu nhỏ",
+    "maximize": "Mở trình soạn thảo đầy đủ",
+    "close": "Đóng",
+    "openDraft": "Mở bản nháp",
+    "continueDraft": "Tiếp tục viết",
+    "save": "Lưu",
+    "publish": "Xuất bản",
+    "statusIdle": "Chưa lưu",
+    "statusSaving": "Đang lưu…",
+    "statusSaved": "Đã lưu",
+    "statusError": "Lỗi"
   }
 }


### PR DESCRIPTION
## Summary

- **WritingModalContext** — isolated React context with 2s auto-save debounce, server-first draft loading on open, publish flow, and open/minimize/close state management
- **WritingModal component** — fixed bottom-right floating panel (desktop only, hidden on mobile) that reuses `NovelEditor` and `FormattingToolbar` as-is; minimized state renders a floating pill button
- **Draft detection on login** — calls `GET /stories/my-draft` when user authenticates; shows minimized pill automatically if an active draft exists
- **Root-level mounting** — `WritingModalProvider` + `WritingModal` added to `Providers.jsx` so modal state persists across all page navigations
- **i18n** — added `writingModal.*` keys to both `en.json` and `vi.json`

## What a reviewer should know

**Reuse decisions (per task spec §7):**
| Component | Decision | Reason |
|---|---|---|
| `NovelEditor` | Reuse as-is | Clean abstraction, no changes needed |
| `FormattingToolbar` | Reuse as-is | Correct TipTap `onMouseDown` pattern |
| `storiesAPI` | Reuse as-is | `getMyDraft`, `patch`, `update`, `create` all fit directly |
| `StoryEditorContainer` global state | Not reused | Isolated state per spec §5.1 |

**Key behaviors:**
- Modal is **desktop-only** (`hidden md:flex`) — mobile users keep the full editor page unchanged
- Draft content is always fetched fresh from the server when modal opens (not from memory cache) — server is source of truth
- Auto-save uses 2s debounce with `clearTimeout` on each keystroke to cancel in-flight timers
- **Maximize** flushes a pending save then navigates to `/stories/{id}/edit`
- **Publish** sets visibility to `public` then closes and resets the modal so the published draft is never re-surfaced
- State is fully isolated from `StoryEditorContainer` — no shared refs or context

## Test plan

- [ ] Log in with an account that has an existing draft — minimized pill appears automatically
- [ ] Click pill → modal opens, draft content loads from server
- [ ] Type in modal → status badge cycles idle → saving → saved after 2s idle
- [ ] Click Minimize → pill reappears; click again → modal reopens with fresh server data
- [ ] Click Maximize → navigates to full editor page
- [ ] Publish a draft → modal closes and pill does not reappear for that draft
- [ ] On mobile viewport — no modal or pill renders
- [ ] Log in with no draft — no pill appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)